### PR TITLE
Document the boolean true? and false? predicates

### DIFF
--- a/docs/source/getting-started/syntax.md
+++ b/docs/source/getting-started/syntax.md
@@ -462,6 +462,19 @@ Arrays are created using flat brackets:
 
 Booleans are created using `true` and `false`.
 
+Inko doesn't have a dedicated negation operator such as `!expression` or `not expression`.
+Instead, you'd use the predicate methods `Bool.true?` and `Bool.false?`.
+`Bool.true?` returns `true` if its receiver is also `true`,
+while `Bool.false?` returns `true` if the receiver is `false.`
+
+Here's a simple example:
+
+```inko
+if volume_is_too_loud.false? {
+  turn_volume_to(11)
+}
+```
+
 ### Nil
 
 The `nil` keyword is used to create an instance of `Nil`.


### PR DESCRIPTION
I know the docs aren't meant to cover standard library behaviours, but one surprising feature of Inko is that it doesn't have a negation operator common in many languages.

This documents the `true?` and `false?` predicates with the express purpose of mentioning how to get negation in Inko using the `false?` predicate.

Inspired by [this Discord discussion](https://discord.com/channels/1044083486509781122/1044083486509781125/1085688571115081780)