### PR TITLE
feat: Replace use of the `libc` crate with the `rustix` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "blake2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +197,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "errno"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,9 +301,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "llvm-sys"
@@ -376,7 +409,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
 dependencies = [
  "autocfg",
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "concurrent-queue",
  "libc",
@@ -445,7 +478,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -481,6 +514,7 @@ dependencies = [
  "libc",
  "polling",
  "rand",
+ "rustix",
  "socket2",
  "unicode-segmentation",
 ]
@@ -490,6 +524,19 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.38.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc6396159432b5c8490d4e301d8c705f61860b8b6c863bf79942ce5401968f3"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "scopeguard"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = ["ast", "inko", "compiler", "rt"]
+resolver = "2"
 
 [profile.release]
 panic = "abort"

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -19,6 +19,7 @@ rand = { version = "^0.8", features = ["default", "small_rng"] }
 polling = "^2.8"
 unicode-segmentation = "^1.8"
 backtrace = "^0.3"
+rustix = { version = "^0.38", features = ["fs", "mm", "param", "process", "net", "std", "time"], default-features = false }
 
 [dependencies.socket2]
 version = "^0.5"

--- a/rt/src/page.rs
+++ b/rt/src/page.rs
@@ -1,16 +1,11 @@
-use libc::{sysconf, _SC_PAGESIZE};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 static PAGE_SIZE: AtomicUsize = AtomicUsize::new(0);
 
-fn page_size_raw() -> usize {
-    unsafe { sysconf(_SC_PAGESIZE) as usize }
-}
-
 pub(crate) fn page_size() -> usize {
     match PAGE_SIZE.load(Ordering::Relaxed) {
         0 => {
-            let size = page_size_raw();
+            let size = rustix::param::page_size();
 
             PAGE_SIZE.store(size, Ordering::Relaxed);
             size

--- a/rt/src/scheduler/mod.rs
+++ b/rt/src/scheduler/mod.rs
@@ -5,19 +5,14 @@ pub mod timeouts;
 use std::thread::available_parallelism;
 
 #[cfg(target_os = "linux")]
-use {
-    libc::{cpu_set_t, sched_setaffinity, CPU_SET},
-    std::mem::{size_of, zeroed},
-};
+use rustix::process::{sched_setaffinity, CpuSet, Pid};
 
 #[cfg(target_os = "linux")]
 pub(crate) fn pin_thread_to_core(core: usize) {
-    unsafe {
-        let mut set: cpu_set_t = zeroed();
+    let mut set = CpuSet::new();
+    set.set(core);
 
-        CPU_SET(core, &mut set);
-        sched_setaffinity(0, size_of::<cpu_set_t>(), &set);
-    }
+    let _ = sched_setaffinity(Pid::from_raw(0), &set);
 }
 
 #[cfg(not(target_os = "linux"))]


### PR DESCRIPTION
This PR is served for this issue #521.

As discussed some days ago, I will leave the time functions as it is for the time being, as these can easily be ported to Inko itself using [the new FFI]( https://github.com/inko-lang/inko/pull/578).

Also, there's a function I can't find an alternative to in `rustix`, see the code below:
https://github.com/inko-lang/inko/blob/59578a133dde292f3dcae7a4d3fd3bd54d8a87d5/rt/src/runtime.rs#L31-L43

Therefore, I still keep it in `libc`. If you have any ideas, please review and advise, I will update my PR.

## How Has This Been Tested?
Existing tests pass.

## What process can a PR reviewer use to test or verify this change?
Check the new `rustix` replacements are correct.

