### PR TITLE
Add "concurrency" feature of github actions to CI

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,10 @@ on:
   workflow_dispatch:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}


### PR DESCRIPTION
This will cancel previous jobs triggered from a PR if a newer job was
triggered by that PR, such as from an update.
