### PR TITLE
Fix outdated codes in doc comments

### DIFF
--- a/std/src/std/array.inko
+++ b/std/src/std/array.inko
@@ -187,7 +187,7 @@ class builtin Array[T] {
   #     let array = []
   #
   #     array.push(10) # => Nil
-  #     array[0]       # => 10
+  #     array.get(0)   # => 10
   fn pub mut push(value: T) {
     reserve(1)
     write_to(@size, value)
@@ -459,7 +459,7 @@ class builtin Array[T] {
   # # Examples
   #
   #     [10].empty? # => false
-  #     [].empty?     # => true
+  #     [].empty?   # => true
   fn pub empty? -> Bool {
     @size == 0
   }

--- a/std/src/std/byte_array.inko
+++ b/std/src/std/byte_array.inko
@@ -116,8 +116,8 @@ class builtin ByteArray {
   #
   #     let bytes = ByteArray.filled(with: 0, times: 2)
   #
-  #     bytes[0] # => 0
-  #     bytes[1] # => 0
+  #     bytes.get(0) # => 0
+  #     bytes.get(1) # => 0
   fn pub static filled(with: Int, times: Int) -> ByteArray {
     let bytes = new
 
@@ -161,7 +161,7 @@ class builtin ByteArray {
   #     let bytes = ByteArray.new
   #
   #     bytes.push(10) # => 10
-  #     bytes.size   # => 1
+  #     bytes.size     # => 1
   fn pub mut push(value: Int) {
     inko_byte_array_push(self, value)
     _INKO.moved(value)
@@ -178,7 +178,7 @@ class builtin ByteArray {
   #
   #     let bytes = ByteArray.from_array([10])
   #
-  #     bytes.pop    # => Option.Some(10)
+  #     bytes.pop  # => Option.Some(10)
   #     bytes.size # => 0
   #
   # Popping a value when the `ByteArray` is empty:
@@ -202,7 +202,7 @@ class builtin ByteArray {
   #     let bytes = ByteArray.from_array([10])
   #
   #     bytes.remove_at(0) # => 10
-  #     bytes.size       # => 0
+  #     bytes.size         # => 0
   #
   # # Panics
   #
@@ -265,7 +265,7 @@ class builtin ByteArray {
   #
   #     let bytes = ByteArray.from_array([10, 20])
   #
-  #     bytes[0] # => 10
+  #     bytes.get(0) # => 10
   fn pub get(index: Int) -> Int {
     bounds_check(index, size)
     inko_byte_array_get(self, index)
@@ -283,8 +283,8 @@ class builtin ByteArray {
   #
   #     let bytes = ByteArray.from_array([10, 20])
   #
-  #     bytes[0] = 30 # => 30
-  #     bytes[0]      # => 30
+  #     bytes.set(0, 30)
+  #     bytes.get(0) # => 30
   fn pub mut set(index: Int, value: Int) {
     bounds_check(index, size)
     inko_byte_array_set(self, index, value)
@@ -420,7 +420,7 @@ impl Bytes for ByteArray {
   #
   # Obtaining the size of a `ByteArray`
   #
-  #     ByteArray.new.size     # => 0
+  #     ByteArray.new.size              # => 0
   #     ByteArray.from_array([10]).size # => 1
   fn pub size -> Int {
     inko_byte_array_size(self)
@@ -439,8 +439,8 @@ impl Bytes for ByteArray {
   #     let bytes = ByteArray.from_array([1, 2, 3, 4])
   #     let sliced = bytes.slice(start: 1, size: 2)
   #
-  #     sliced[0] # => 2
-  #     sliced[1] # => 3
+  #     sliced.get(0) # => 2
+  #     sliced.get(1) # => 3
   fn pub slice(start: Int, size: Int) -> ByteArray {
     bounds_check(start, self.size)
     inko_byte_array_slice(_INKO.state, self, start, size)

--- a/std/src/std/byte_array.inko
+++ b/std/src/std/byte_array.inko
@@ -226,7 +226,7 @@ class builtin ByteArray {
   #     let bytes = ByteArray.from_array([105, 110, 107, 111])
   #
   #     bytes.drain_to_string # => 'inko'
-  #     bytes.empty?          # => True
+  #     bytes.empty?          # => true
   fn pub mut drain_to_string -> String {
     inko_byte_array_drain_to_string(_INKO.state, self)
   }
@@ -502,7 +502,7 @@ impl IntoString for ByteArray {
 }
 
 impl Equal[ByteArray] for ByteArray {
-  # Returns `True` if two `ByteArray` objects are equal to each other.
+  # Returns `true` if two `ByteArray` objects are equal to each other.
   #
   # Two `ByteArray` objects are considered equal if they have the exact same
   # values in the exact same order.
@@ -511,8 +511,8 @@ impl Equal[ByteArray] for ByteArray {
   #
   # Comparing two `ByteArray` objects:
   #
-  #     ByteArray.from_array([10]) == ByteArray.from_array([10]) # => True
-  #     ByteArray.from_array([10]) == ByteArray.from_array([20]) # => False
+  #     ByteArray.from_array([10]) == ByteArray.from_array([10]) # => true
+  #     ByteArray.from_array([10]) == ByteArray.from_array([20]) # => false
   fn pub ==(other: ref ByteArray) -> Bool {
     inko_byte_array_eq(self, other)
   }

--- a/std/src/std/cmp.inko
+++ b/std/src/std/cmp.inko
@@ -88,7 +88,7 @@ trait pub Compare[T] {
 
 # A type that can be compared for equality.
 trait pub Equal[T] {
-  # Returns `True` if `self` and the given object are equal to each other.
+  # Returns `true` if `self` and the given object are equal to each other.
   #
   # This operator is used to perform structural equality. This means two objects
   # residing in different memory locations may be considered equal, provided
@@ -97,7 +97,7 @@ trait pub Equal[T] {
   # values.
   fn pub ==(other: ref T) -> Bool
 
-  # Returns `True` if `self` and the given object are not equal to each other.
+  # Returns `true` if `self` and the given object are not equal to each other.
   fn pub !=(other: ref T) -> Bool {
     (self == other).false?
   }

--- a/std/src/std/fs/path.inko
+++ b/std/src/std/fs/path.inko
@@ -89,7 +89,7 @@ fn extern inko_time_system_offset -> Int64
 # The character used to separate components in a file path.
 let pub SEPARATOR = '/'
 
-# Returns `True` if the byte is a valid path separator byte.
+# Returns `true` if the byte is a valid path separator byte.
 fn path_separator?(byte: Int) -> Bool {
   byte == 47
 }
@@ -125,7 +125,7 @@ fn bytes_before_last_separator(path: String) -> Int {
   if in_separator { 1 } else { -1 }
 }
 
-# Returns `True` if the given file path is an absolute path.
+# Returns `true` if the given file path is an absolute path.
 fn absolute_path?(path: String) -> Bool {
   path_separator?(path.byte(0))
 }
@@ -191,17 +191,17 @@ class pub Path {
     Path { @path = path }
   }
 
-  # Returns `True` if the path points to a file.
+  # Returns `true` if the path points to a file.
   fn pub file? -> Bool {
     inko_path_is_file(_INKO.process, @path)
   }
 
-  # Returns `True` if the path points to a directory.
+  # Returns `true` if the path points to a directory.
   fn pub directory? -> Bool {
     inko_path_is_directory(_INKO.process, @path)
   }
 
-  # Returns `True` if the path points to an existing file or directory.
+  # Returns `true` if the path points to an existing file or directory.
   fn pub exists? -> Bool {
     inko_path_exists(_INKO.process, @path)
   }
@@ -272,7 +272,7 @@ class pub Path {
     }
   }
 
-  # Returns `True` if this `Path` is an absolute path.
+  # Returns `true` if this `Path` is an absolute path.
   #
   # # Examples
   #
@@ -280,13 +280,13 @@ class pub Path {
   #
   #     import std.fs.path.Path
   #
-  #     Path.new('foo').absolute?  # => False
-  #     Path.new('/foo').absolute? # => True
+  #     Path.new('foo').absolute?  # => false
+  #     Path.new('/foo').absolute? # => true
   fn pub absolute? -> Bool {
     absolute_path?(@path)
   }
 
-  # Returns `True` if this `Path` is a relative path.
+  # Returns `true` if this `Path` is a relative path.
   #
   # # Examples
   #
@@ -294,9 +294,9 @@ class pub Path {
   #
   #     import std.fs.path.Path
   #
-  #     Path.new('foo').relative?  # => True
-  #     Path.new('../').relative?  # => True
-  #     Path.new('/foo').relative? # => False
+  #     Path.new('foo').relative?  # => true
+  #     Path.new('../').relative?  # => true
+  #     Path.new('/foo').relative? # => false
   fn pub relative? -> Bool {
     absolute?.false?
   }
@@ -585,7 +585,7 @@ trait pub IntoPath {
 }
 
 impl Equal[Path] for Path {
-  # Returns `True` if `self` is equal to the given `Path`.
+  # Returns `true` if `self` is equal to the given `Path`.
   #
   # # Examples
   #
@@ -596,7 +596,7 @@ impl Equal[Path] for Path {
   #     let path1 = Path.new('foo')
   #     let path2 = Path.new('foo')
   #
-  #     path1 == path2 # => True
+  #     path1 == path2 # => true
   fn pub ==(other: ref Path) -> Bool {
     @path == other.to_string
   }

--- a/std/src/std/iter.inko
+++ b/std/src/std/iter.inko
@@ -100,7 +100,7 @@ trait pub Iter[T] {
     }
   }
 
-  # Returns the first value for which the supplied `Block` returns `True`.
+  # Returns the first value for which the supplied `Block` returns `true`.
   #
   # This method will advance the `Iter` until either a value is found or we
   # run out of values.
@@ -146,8 +146,8 @@ trait pub Iter[T] {
     }
   }
 
-  # Returns `True` if `self` contains any value for which the `func` argument
-  # returned `True`.
+  # Returns `true` if `self` contains any value for which the `func` argument
+  # returned `true`.
   #
   # This method stops iterating over the values after the first matching value.
   #
@@ -155,7 +155,7 @@ trait pub Iter[T] {
   #
   # Checking if an `Iter` contains a value:
   #
-  #     [10, 20, 30].iter.any? fn (value) { value >= 20 } # => True
+  #     [10, 20, 30].iter.any? fn (value) { value >= 20 } # => true
   fn pub mut any?(func: fn (T) -> Bool) -> Bool {
     loop {
       match self.next {
@@ -166,7 +166,7 @@ trait pub Iter[T] {
   }
 
   # Returns an `Iter` that only produces values for which the supplied func
-  # returned `True`.
+  # returned `true`.
   #
   # # Examples
   #
@@ -217,8 +217,8 @@ trait pub Iter[T] {
   # Partitions the `Iter` into a tuple of two `Array` objects.
   #
   # The first value of the tuple contains all values for which the supplied
-  # func returned `True`. The second value contains all values for which the
-  # func returned `False`.
+  # func returned `true`. The second value contains all values for which the
+  # func returned `false`.
   #
   # # Examples
   #
@@ -237,18 +237,18 @@ trait pub Iter[T] {
     }
   }
 
-  # Returns `True` if the supplied func returns `True` for _all_ values in
+  # Returns `true` if the supplied func returns `true` for _all_ values in
   # `self`.
   #
   # This method stops iterating over the values after the first value for which
-  # the closure returns `False`.
+  # the closure returns `false`.
   #
   # # Examples
   #
   # Checking if all values in an `Iter` match a condition:
   #
-  #     [10, 20].iter.all? fn (value) { value.positive? } # => True
-  #     [-1, 20].iter.all? fn (value) { value.positive? } # => False
+  #     [10, 20].iter.all? fn (value) { value.positive? } # => true
+  #     [-1, 20].iter.all? fn (value) { value.positive? } # => false
   fn pub mut all?(func: fn (T) -> Bool) -> Bool {
     loop {
       match self.next {

--- a/std/src/std/range.inko
+++ b/std/src/std/range.inko
@@ -114,8 +114,8 @@ impl Contains[Int] for InclusiveRange {
   #
   # Checking if a `Range` covers a value:
   #
-  #     1.to(10).cover?(5)  # => true
-  #     1.to(10).cover?(10) # => true
+  #     1.to(10).contains?(5)  # => true
+  #     1.to(10).contains?(10) # => true
   fn pub contains?(value: ref Int) -> Bool {
     @start <= value and value <= @end
   }

--- a/std/src/std/set.inko
+++ b/std/src/std/set.inko
@@ -12,7 +12,7 @@ class pub Set[V: Hash + Equal[V]] {
   # The Map used for storing values.
   #
   # The keys are the values inserted in this `Set`, the values are always set to
-  # `True`.
+  # `true`.
   let @map: Map[V, Bool]
 
   fn pub static new -> Set[V] {
@@ -21,7 +21,7 @@ class pub Set[V: Hash + Equal[V]] {
 
   # Inserts a new value into the `Set`.
   #
-  # The returned value is `True` if the value was inserted, `False` otherwise.
+  # The returned value is `true` if the value was inserted, `false` otherwise.
   #
   # # Examples
   #
@@ -38,7 +38,7 @@ class pub Set[V: Hash + Equal[V]] {
 
   # Removes a value from this `Set`.
   #
-  # If the value was removed `True` is returned, otherwise `False` is returned.
+  # If the value was removed `true` is returned, otherwise `false` is returned.
   #
   # # Examples
   #
@@ -49,8 +49,8 @@ class pub Set[V: Hash + Equal[V]] {
   #     let set = Set.new
   #
   #     set.insert(10)
-  #     set.remove(10) # => True
-  #     set.remove(10) # => False
+  #     set.remove(10) # => true
+  #     set.remove(10) # => false
   #
   # Removing a non-existing value from a `Set`:
   #
@@ -58,7 +58,7 @@ class pub Set[V: Hash + Equal[V]] {
   #
   #     let set = Set.new
   #
-  #     set.remove(10) # => False
+  #     set.remove(10) # => false
   fn pub mut remove(value: ref V) -> Bool {
     @map.remove(value).some?
   }
@@ -104,7 +104,7 @@ class pub Set[V: Hash + Equal[V]] {
 }
 
 impl Equal[Set[V]] for Set {
-  # Returns `True` if `self` and the given `Set` are identical to each
+  # Returns `true` if `self` and the given `Set` are identical to each
   # other.
   #
   # # Examples
@@ -119,7 +119,7 @@ impl Equal[Set[V]] for Set {
   #     set1.insert(10)
   #     set2.insert(10)
   #
-  #     set1 == set2 # => True
+  #     set1 == set2 # => true
   fn pub ==(other: ref Set[V]) -> Bool {
     if size != other.size { return false }
 
@@ -128,7 +128,7 @@ impl Equal[Set[V]] for Set {
 }
 
 impl Contains[V] for Set {
-  # Returns `True` if this `Set` contains the given value.
+  # Returns `true` if this `Set` contains the given value.
   #
   # # Examples
   #
@@ -138,9 +138,9 @@ impl Contains[V] for Set {
   #
   #     let set = Set.new
   #
-  #     set.contains?(10) # => False
+  #     set.contains?(10) # => false
   #     set.insert(10)
-  #     set.contains?(10) # => True
+  #     set.contains?(10) # => true
   fn pub contains?(value: ref V) -> Bool {
     @map.contains?(value)
   }

--- a/std/src/std/sys.inko
+++ b/std/src/std/sys.inko
@@ -372,14 +372,14 @@ class pub ExitStatus {
     ExitStatus { @code = code }
   }
 
-  # Returns `True` if the status signals success.
+  # Returns `true` if the status signals success.
   #
   # # Examples
   #
   #     import std.sys.ExitStatus
   #
-  #     ExitStatus.new(0).success? # => True
-  #     ExitStatus.new(1).success? # => False
+  #     ExitStatus.new(0).success? # => true
+  #     ExitStatus.new(1).success? # => false
   fn pub success? -> Bool {
     @code == 0
   }


### PR DESCRIPTION
Replaced `True` / `False` with `true` / `false`, `array[i]` with `array.get(i)`, and made other small fixes.