### PR TITLE
Two minor documentation tweaks

### DIFF
--- a/docs/source/guides/syntax.md
+++ b/docs/source/guides/syntax.md
@@ -635,7 +635,6 @@ match foo {
 
 The receiver of the `match` expression cannot be a trait.
 
-
 ### Closures
 
 Closures are created using the `fn` keyword:

--- a/docs/source/guides/syntax.md
+++ b/docs/source/guides/syntax.md
@@ -347,7 +347,7 @@ trait ToString {
 }
 ```
 
-Traits aren't allowed to define static methods.
+Traits aren't allowed to define static methods and cannot be used to specify async method interfaces.
 
 Traits can also define type parameters:
 
@@ -632,6 +632,9 @@ match foo {
   case _ -> bar
 }
 ```
+
+The receiver of the `match` expression cannot be a trait.
+
 
 ### Closures
 

--- a/docs/source/guides/syntax.md
+++ b/docs/source/guides/syntax.md
@@ -347,7 +347,7 @@ trait ToString {
 }
 ```
 
-Traits aren't allowed to define static methods and cannot be used to specify async method interfaces.
+Traits can't specify static or async methods.
 
 Traits can also define type parameters:
 


### PR DESCRIPTION
* Document that it's not possible to match on a trait.
* Document that it is not possible to define a trait with async methods.