### PR TITLE
Disallow symbol imports from another module

### DIFF
--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -2618,6 +2618,28 @@ impl ModuleId {
         self.get(db).symbols.contains_key(name)
     }
 
+    pub fn import_symbol(self, db: &Database, name: &str) -> Option<Symbol> {
+        let Some(symbol) = self.symbol(db, name) else {
+            return None;
+        };
+
+        let module_id = match symbol {
+            Symbol::Class(id) => id.module(db),
+            Symbol::Trait(id) => id.module(db),
+            Symbol::Constant(id) => id.module(db),
+            Symbol::Method(id) => id.module(db),
+            Symbol::Module(id) => id,
+            // Type parameters can't be imported.
+            Symbol::TypeParameter(_) => return None,
+        };
+
+        if self == module_id {
+            Some(symbol)
+        } else {
+            None
+        }
+    }
+
     pub fn new_symbol(self, db: &mut Database, name: String, symbol: Symbol) {
         self.get_mut(db).symbols.insert(name, symbol);
     }

--- a/types/src/test.rs
+++ b/types/src/test.rs
@@ -1,9 +1,14 @@
 use crate::{
-    Class, ClassId, ClassInstance, ClassKind, ClosureId, Database, ModuleId,
-    Trait, TraitId, TraitImplementation, TraitInstance, TypeArguments,
-    TypeBounds, TypeId, TypeParameter, TypeParameterId, TypePlaceholderId,
-    TypeRef, Visibility,
+    Class, ClassId, ClassInstance, ClassKind, ClosureId, Database, Module,
+    ModuleId, ModuleName, Trait, TraitId, TraitImplementation, TraitInstance,
+    TypeArguments, TypeBounds, TypeId, TypeParameter, TypeParameterId,
+    TypePlaceholderId, TypeRef, Visibility,
 };
+use std::path::PathBuf;
+
+pub(crate) fn new_module(db: &mut Database, name: &str) -> ModuleId {
+    Module::alloc(db, ModuleName::new(name), PathBuf::from("foo.inko"))
+}
 
 pub(crate) fn new_class(db: &mut Database, name: &str) -> ClassId {
     Class::alloc(


### PR DESCRIPTION
This commit fixes a compiler bug that allowed to import symbols that were not defined in the module, but only imported from another module.

Changelog: fixed

Closes https://github.com/inko-lang/inko/issues/603
