### PR TITLE
Fix: rm usage of undefined function "remove"

### DIFF
--- a/docs/source/getting-started/error-handling.md
+++ b/docs/source/getting-started/error-handling.md
@@ -221,7 +221,7 @@ class async Main {
     file.read_all(bytes).expect('failed to read the file')
     STDOUT.new.write_bytes(bytes).expect('failed to write to STDOUT')
 
-    let _ = remove(file.path)
+    let _ = file.path.remove_file
   }
 }
 ```


### PR DESCRIPTION
It looks like the docs referenced a function that has been deprecated/removed. I replaced it with [remove_file](https://github.com/inko-lang/inko/blob/8f5ad1e56756fe00325a3b4ed0fc3c46e1d50e65/std/src/std/fs/path.inko#L445) from `std.fs.path`.

https://github.com/inko-lang/inko/blob/8f5ad1e56756fe00325a3b4ed0fc3c46e1d50e65/docs/source/getting-started/error-handling.md?plain=1#L224