### PR TITLE
Optimize pkg add/sync/update by cloning single branch

### DIFF
--- a/inko/src/command/pkg/add.rs
+++ b/inko/src/command/pkg/add.rs
@@ -45,19 +45,19 @@ pub(crate) fn run(args: &[String]) -> Result<i32, Error> {
         matches.free.get(1).and_then(|uri| Version::parse(uri)).ok_or_else(
             || Error::from("The package version is invalid".to_string()),
         )?;
+    let tag_name = version.tag_name();
 
     let dir = data_dir()?.join(url.directory_name());
     let (mut repo, fetch) = if dir.is_dir() {
         (Repository::open(&dir)?, true)
     } else {
-        (Repository::clone(&url.to_string(), &dir)?, false)
+        (Repository::clone(&url.to_string(), &dir, &tag_name)?, false)
     };
 
     if fetch {
         repo.fetch()?;
     }
 
-    let tag_name = version.tag_name();
     let tag = if let Some(tag) = repo.tag(&tag_name) {
         Some(tag)
     } else if fetch {

--- a/inko/src/command/pkg/sync.rs
+++ b/inko/src/command/pkg/sync.rs
@@ -85,14 +85,14 @@ fn download_dependency(
 ) -> Result<(Package, Option<Manifest>), Error> {
     let dir = cache_dir.join(dependency.url.directory_name());
     let url = dependency.url.to_string();
+    let tag_name = dependency.version.tag_name();
     let (mut repo, fetch) = if dir.is_dir() {
         (Repository::open(&dir)?, true)
     } else {
         println!("Downloading {} v{}", dependency.url, dependency.version);
-        (Repository::clone(&url, &dir)?, false)
+        (Repository::clone(&url, &dir, &tag_name)?, false)
     };
 
-    let tag_name = dependency.version.tag_name();
     let tag = if let Some(tag) = repo.tag(&tag_name) {
         Some(tag)
     } else if fetch {

--- a/inko/src/command/pkg/update.rs
+++ b/inko/src/command/pkg/update.rs
@@ -60,7 +60,11 @@ pub(crate) fn run(args: &[String]) -> Result<i32, Error> {
             repo.fetch()?;
             repo
         } else {
-            Repository::clone(&dep.url.to_string(), &dir)?
+            Repository::clone(
+                &dep.url.to_string(),
+                &dir,
+                &dep.version.tag_name(),
+            )?
         };
 
         let tag_names = repo.version_tag_names();

--- a/inko/src/pkg/git.rs
+++ b/inko/src/pkg/git.rs
@@ -26,9 +26,23 @@ impl Repository {
         }
     }
 
-    pub(crate) fn clone(url: &str, path: &Path) -> Result<Self, String> {
-        run("clone", None, &[OsStr::new(url), path.as_os_str()])
-            .map_err(|err| format!("Failed to clone {}: {}", url, err))?;
+    pub(crate) fn clone(
+        url: &str,
+        path: &Path,
+        branch: &str,
+    ) -> Result<Self, String> {
+        run(
+            "clone",
+            None,
+            &[
+                OsStr::new("--single-branch"),
+                OsStr::new("--branch"),
+                OsStr::new(branch),
+                OsStr::new(url),
+                path.as_os_str(),
+            ],
+        )
+        .map_err(|err| format!("Failed to clone {}: {}", url, err))?;
 
         Ok(Self { path: path.to_path_buf() })
     }


### PR DESCRIPTION
Fixes https://github.com/inko-lang/inko/issues/736

Use `git clone --single-branch --branch $tag $repo` to prevent fetching unnecessary branches.

The `--single-branch` flag  has two effects:

- Git fetches only the specified branch or tag during the initial clone and checks it out.
- It sets an option in .git/config, preventing subsequent `git fetch` from fetching all branches but the initially specified one. (`git fetch --tags` will still fetch all tags.)

---

Below, I exercised the pkg commands in several scenarios.

```
# Go to package cache dir
% pwd
/Users/uasi/Library/Application Support/inko/packages
% ls
(empty)

# Add inko-tmp_fetch_testing v0.0.1
% ( cd ~/inko ; cargo r pkg add github.com/uasi/inko-tmp_fetch_testing 0.0.1 )

# Only v0.0.1 is checked out, no `master` or `unneeded` branches or other tags
% cd 3abe66e7968b592e1cd237e089d84a9f5903a98f80ba355c7814be3c75f7c6cd
% git branch -r
% git tag -l
v0.0.1
% git log -n1 --oneline
f8dc746 (HEAD, tag: v0.0.1) Release v0.0.1

# Check if re-adding the package works, using v0.0.2 this time
% ( cd ~/inko ; cargo r pkg add github.com/uasi/inko-tmp_fetch_testing 0.0.2 )

# No branches are fetched, *all* tags are fetched due to `git fetch --tags`, still on v0.0.1
% git branch -r
% git tag -l
v0.0.1
v0.0.2
v0.0.3
% git log -n1 --oneline
f8dc746 (HEAD, tag: v0.0.1) Release v0.0.1

# pkg sync checks out v0.0.2
% ( cd ~/inko ; cargo r pkg sync )
% git log -n1 --oneline
da87e37 (HEAD, tag: v0.0.2) Release v0.0.2

# Check if pkg update works
( cd ~/inko ; cargo r pkg update github.com/uasi/inko-tmp_fetch_testing )

# Again no branches are fetched, all tags are fetched already, still on v0.0.2
% git branch -r
% git tag -l
v0.0.1
v0.0.2
v0.0.3
% git log -n1 --oneline
da87e37 (HEAD, tag: v0.0.2) Release v0.0.2

# pkg sync checks out v0.0.3
% ( cd ~/inko ; cargo r pkg sync )
% git log -n1 --oneline
aaa917c (HEAD, tag: v0.0.3) Release v0.0.3 (diverged from v0.0.2)
```