### PR TITLE
Support minimum required Inko version in inko.pkg

### DIFF
--- a/inko/src/command/pkg/remove.rs
+++ b/inko/src/command/pkg/remove.rs
@@ -33,7 +33,8 @@ pub(crate) fn run(args: &[String]) -> Result<i32, Error> {
         .and_then(|uri| Url::parse(uri))
         .ok_or_else(|| "The package URL is invalid".to_string())?;
 
-    let mut manifest = Manifest::load(&MANIFEST_FILE)?;
+    let mut manifest = Manifest::load(&MANIFEST_FILE)
+        .map_err(|e| format!("Failed to load the manifest: {}", e))?;
 
     manifest.remove_dependency(&url);
     manifest.save(&MANIFEST_FILE)?;

--- a/inko/src/command/pkg/update.rs
+++ b/inko/src/command/pkg/update.rs
@@ -36,7 +36,8 @@ pub(crate) fn run(args: &[String]) -> Result<i32, Error> {
     }
 
     let major = matches.opt_present("m");
-    let mut manifest = Manifest::load(&MANIFEST_FILE)?;
+    let mut manifest = Manifest::load(&MANIFEST_FILE)
+        .map_err(|e| format!("Failed to load the manifest: {}", e))?;
     let update = if let Some(url) =
         matches.free.first().and_then(|uri| Url::parse(uri))
     {


### PR DESCRIPTION
Closes https://github.com/inko-lang/inko/issues/723

This pull request adds support for the `inko version X.Y.Z` line in inko.pkg. The minimum requirement does not imply semver compatibility: for example, Inko version 2.0.0 will satisfy a minimum requirement of 1.0.0.

Also, I've gone slightly beyond the original scope and implemented the `inko pkg add inko X.Y.Z` command.