### PR TITLE
Add Iter.chain method

### DIFF
--- a/std/src/std/iter.inko
+++ b/std/src/std/iter.inko
@@ -301,6 +301,29 @@ trait pub Iter[T] {
     }
   }
 
+  # Join two `Iter` objects together, one after another.
+  #
+  # # Examples
+  #
+  # ```inko
+  # let a = [10, 20, 30]
+  # let b = [40, 50, 60]
+  # a.iter.chain(b.iter).to_array == [10, 20, 30, 40, 50, 60] # => true
+  # ```
+  fn pub move chain[I: mut + Iter[T]](other: I) -> Stream[T] {
+    let mut iter_left = true
+
+    Stream.new(fn move {
+      if iter_left {
+        let item = self.next
+
+        if item.some? { return item } else { iter_left = false }
+      }
+
+      other.next
+    })
+  }
+
   # Zips two `Iter` objects together, producing a new `Iter` that produces a
   # tuple containing the values of both `Iter` objects.
   #

--- a/std/test/std/test_iter.inko
+++ b/std/test/std/test_iter.inko
@@ -116,6 +116,13 @@ fn pub tests(t: mut Tests) {
     t.equal(iter.next, Option.Some(ref 30))
   })
 
+  t.test('Iter.chain', fn (t) {
+    let a = [10, 20, 30]
+    let b = [40, 50, 60]
+
+    t.equal(a.iter.chain(b.iter).to_array, [10, 20, 30, 40, 50, 60])
+  })
+
   t.test('Iter.zip', fn (t) {
     let a = [10, 20]
     let b = [30, 40]


### PR DESCRIPTION
This joins two iterators without requiring memory allocations.

Closes #747