### PR TITLE
Add support for inline/stack allocated types

### DIFF
--- a/ast/src/nodes.rs
+++ b/ast/src/nodes.rs
@@ -492,6 +492,7 @@ pub enum ClassKind {
 #[derive(Debug, PartialEq, Eq)]
 pub struct DefineClass {
     pub public: bool,
+    pub inline: bool,
     pub kind: ClassKind,
     pub name: Constant,
     pub type_parameters: Option<TypeParameters>,
@@ -637,6 +638,7 @@ impl Node for ReopenClass {
 pub enum Requirement {
     Trait(TypeName),
     Mutable(Location),
+    Inline(Location),
 }
 
 impl Node for Requirement {
@@ -644,6 +646,7 @@ impl Node for Requirement {
         match self {
             Requirement::Trait(n) => &n.location,
             Requirement::Mutable(loc) => loc,
+            Requirement::Inline(loc) => loc,
         }
     }
 }

--- a/compiler/src/diagnostics.rs
+++ b/compiler/src/diagnostics.rs
@@ -256,6 +256,24 @@ impl Diagnostics {
         );
     }
 
+    pub(crate) fn not_a_stack_type(
+        &mut self,
+        name: &str,
+        file: PathBuf,
+        location: Location,
+    ) {
+        self.error(
+            DiagnosticId::InvalidType,
+            format!(
+                "an 'inline' or 'extern' type is expected, \
+                but '{}' is a heap type",
+                name
+            ),
+            file,
+            location,
+        );
+    }
+
     pub(crate) fn fields_not_allowed(
         &mut self,
         name: &str,
@@ -841,15 +859,34 @@ impl Diagnostics {
         );
     }
 
-    pub(crate) fn type_parameter_already_mutable(
+    pub(crate) fn duplicate_type_parameter_requirement(
         &mut self,
-        name: &str,
+        param: &str,
+        req: &str,
         file: PathBuf,
         location: Location,
     ) {
         self.error(
             DiagnosticId::InvalidType,
-            format!("the type parameter '{}' is already mutable", name),
+            format!(
+                "type parameter '{}' already defines the '{}' requirement",
+                param, req
+            ),
+            file,
+            location,
+        );
+    }
+
+    pub(crate) fn mutable_inline_type_parameter(
+        &mut self,
+        file: PathBuf,
+        location: Location,
+    ) {
+        self.error(
+            DiagnosticId::InvalidType,
+            "type parameters can't be both 'mut' and 'inline', \
+            as 'inline' types are immutable"
+                .to_string(),
             file,
             location,
         );
@@ -973,6 +1010,23 @@ impl Diagnostics {
         self.error(
             DiagnosticId::InvalidMethod,
             "the 'inline' keyword can't be used for this type of method",
+            file,
+            location,
+        );
+    }
+
+    pub(crate) fn invalid_mut_type(
+        &mut self,
+        name: &str,
+        file: PathBuf,
+        location: Location,
+    ) {
+        self.error(
+            DiagnosticId::InvalidType,
+            format!(
+                "mutable borrows of type '{}' are invalid as '{}' is immutable",
+                name, name
+            ),
             file,
             location,
         );

--- a/compiler/src/llvm/methods.rs
+++ b/compiler/src/llvm/methods.rs
@@ -1,8 +1,8 @@
 use crate::llvm::constants::{CLOSURE_CALL_INDEX, DROPPER_INDEX};
 use crate::llvm::method_hasher::MethodHasher;
 use crate::mir::Mir;
+use crate::symbol_names::format_shapes;
 use std::cmp::max;
-use std::fmt::Write as _;
 use types::{Database, MethodId, Shape, CALL_METHOD, DROPPER_METHOD};
 
 /// Method table sizes are multiplied by this value in an attempt to reduce the
@@ -45,10 +45,7 @@ fn round_methods(mut value: usize) -> usize {
 fn hash_key(db: &Database, method: MethodId, shapes: &[Shape]) -> String {
     let mut key = method.name(db).clone();
 
-    for shape in shapes {
-        let _ = write!(key, "{}", shape);
-    }
-
+    format_shapes(db, shapes, &mut key);
     key
 }
 

--- a/compiler/src/mir/inline.rs
+++ b/compiler/src/mir/inline.rs
@@ -32,7 +32,7 @@ fn instruction_weight(db: &Database, instruction: &Instruction) -> u16 {
         // give them a weight of zero. Regular allocations and spawning
         // processes translate into a function call, so we give them the same
         // weight as calls.
-        Instruction::Allocate(ins) if ins.class.kind(db).is_extern() => 0,
+        Instruction::Allocate(ins) if ins.class.is_stack_allocated(db) => 0,
         Instruction::Allocate(_) => 1,
         Instruction::Spawn(_) => 1,
 
@@ -314,7 +314,7 @@ impl CallSite {
                         ins.location.set_inlined_call_id(inline_offset);
                         ins.register += reg_start;
                     }
-                    Instruction::Reference(ins) => {
+                    Instruction::Borrow(ins) => {
                         ins.location.set_inlined_call_id(inline_offset);
                         ins.register += reg_start;
                         ins.value += reg_start;

--- a/compiler/src/mir/pattern_matching.rs
+++ b/compiler/src/mir/pattern_matching.rs
@@ -774,7 +774,7 @@ impl<'a> Compiler<'a> {
                 .into_iter()
                 .map(|t| {
                     self.new_variable(
-                        t.cast_according_to(source_variable_type, self.db()),
+                        t.cast_according_to(self.db(), source_variable_type),
                     )
                 })
                 .collect();
@@ -788,7 +788,7 @@ impl<'a> Compiler<'a> {
                 let inferred =
                     TypeResolver::new(&mut self.state.db, &args, &self.bounds)
                         .resolve(raw_type)
-                        .cast_according_to(source_variable_type, self.db());
+                        .cast_according_to(self.db(), source_variable_type);
 
                 self.new_variable(inferred)
             })
@@ -818,7 +818,8 @@ impl<'a> Compiler<'a> {
                         .constructors(self.db())
                         .into_iter()
                         .map(|constructor| {
-                            let members = constructor.members(self.db());
+                            let members =
+                                constructor.arguments(self.db()).to_vec();
 
                             (
                                 Constructor::Constructor(constructor),

--- a/compiler/src/target.rs
+++ b/compiler/src/target.rs
@@ -237,17 +237,6 @@ impl Target {
         self == &Target::native()
     }
 
-    /// Returns the maximum size (in bits) of a struct that can be passed
-    /// through registers.
-    ///
-    /// If a struct is larger than this size, it must be passed using a pointer.
-    pub(crate) fn pass_struct_size(&self) -> u64 {
-        // The exact size may differ per platform, but both amd64 and arm64 have
-        // the same requirement, and those are the only platforms we support at
-        // this time.
-        128
-    }
-
     pub(crate) fn stack_pointer_register_name(&self) -> &str {
         match self.arch {
             Architecture::Amd64 => "rsp",

--- a/compiler/src/type_check/graph.rs
+++ b/compiler/src/type_check/graph.rs
@@ -1,0 +1,103 @@
+//! Helpers for performing graph-like operations on types, such as checking if a
+//! class is recursive.
+use types::{ClassId, ClassInstance, Database, TypeRef};
+
+#[derive(Copy, Clone)]
+enum Visit {
+    /// The node has yet to be visited.
+    Unvisited,
+
+    /// The node is in the queue but has yet to be visited.
+    ///
+    /// This state exists to ensure we don't schedule the same node multiple
+    /// times.
+    Scheduled,
+
+    /// A node's edges are being visited.
+    Visiting,
+
+    /// The node and its edges have been visited.
+    Visited,
+}
+
+/// A type used for checking if a stack class is a recursive class.
+pub(crate) struct RecursiveClassChecker<'a> {
+    db: &'a Database,
+    states: Vec<Visit>,
+    work: Vec<ClassId>,
+}
+
+impl<'a> RecursiveClassChecker<'a> {
+    pub(crate) fn new(db: &'a Database) -> RecursiveClassChecker<'a> {
+        RecursiveClassChecker {
+            db,
+            states: vec![Visit::Unvisited; db.number_of_classes()],
+            work: Vec::new(),
+        }
+    }
+
+    pub(crate) fn is_recursive(&mut self, class: ClassId) -> bool {
+        self.add(class);
+
+        while let Some(&class) = self.work.last() {
+            if let Visit::Visiting = self.state(class) {
+                self.set_state(class, Visit::Visited);
+                self.work.pop();
+                continue;
+            }
+
+            self.set_state(class, Visit::Visiting);
+
+            for field in class.fields(self.db) {
+                let typ = field.value_type(self.db);
+                let Some(ins) = self.edge(typ) else { continue };
+
+                match self.state(ins.instance_of()) {
+                    Visit::Unvisited => self.add(ins.instance_of()),
+                    Visit::Visiting => return true,
+                    _ => continue,
+                }
+
+                if !ins.instance_of().is_generic(self.db) {
+                    continue;
+                }
+
+                for (_, &typ) in ins.type_arguments(self.db).unwrap().iter() {
+                    let Some(ins) = self.edge(typ) else { continue };
+
+                    match self.state(ins.instance_of()) {
+                        Visit::Unvisited => self.add(ins.instance_of()),
+                        Visit::Visiting => return true,
+                        _ => continue,
+                    }
+                }
+            }
+        }
+
+        false
+    }
+
+    fn edge(&self, typ: TypeRef) -> Option<ClassInstance> {
+        // Pointers _are_ stack allocated, but they introduce indirection that
+        // breaks recursion so we don't need to process them.
+        if typ.is_pointer(self.db) {
+            return None;
+        }
+
+        typ.as_class_instance(self.db)
+            .filter(|v| v.instance_of().is_stack_allocated(self.db))
+    }
+
+    fn set_state(&mut self, id: ClassId, state: Visit) {
+        self.states[id.0 as usize] = state;
+    }
+
+    fn state(&self, id: ClassId) -> Visit {
+        self.states[id.0 as usize]
+    }
+
+    fn add(&mut self, id: ClassId) {
+        self.set_state(id, Visit::Scheduled);
+        self.work.push(id);
+    }
+}

--- a/docs/inko.pkg
+++ b/docs/inko.pkg
@@ -1,3 +1,4 @@
 require https://github.com/yorickpeterse/inko-wobsite 0.19.0 fa5e47733423aa6a902028e69de5a374a1757377
 require https://github.com/yorickpeterse/inko-builder 0.13.0 7a38803e1fcd80e19ad2ea8fd90b9babf70e93a6
 require https://github.com/yorickpeterse/inko-markdown 0.21.0 3726c10b499242cb3febc931a82e35217e2f987a
+require https://github.com/yorickpeterse/inko-syntax 0.13.0 18c5c4c31512c2717fcbf13f6163cbf33e80e2b8

--- a/docs/source/design/compiler.md
+++ b/docs/source/design/compiler.md
@@ -325,3 +325,11 @@ slot = hash & (size - 1)
 To handle conflicts we use linear probing, resulting in an efficient
 implementation of dynamic dispatch. For more information, refer to the article
 ["Shenanigans With Hash Tables"](https://thume.ca/2019/07/29/shenanigans-with-hash-tables/).
+
+### ABI
+
+Officially generated code has no stable ABI, and this is unlikely to change any
+time soon. Internally, we implement the C/system ABI as we need to do so for
+interacting with foreign code anyway. This means that for example structures on
+the stack are passed and returned the same way as is done by C compilers such as
+clang.

--- a/docs/source/getting-started/ffi.md
+++ b/docs/source/getting-started/ffi.md
@@ -655,9 +655,7 @@ of the C libraries out there. Most notably, the following isn't supported:
   support this it wouldn't make your life easier.
 - Compiling C source code as part of the Inko build process.
 - Compile-time expressions such as `sizeof()` to automatically get type sizes.
-- Setting `errno` to a custom value. `errno` is implemented differently across
-  libc implementations, and Rust (which we use for getting the value) doesn't
-  support writing to `errno`.
+- Setting `errno` to a custom value.
 
 [^1]: On 32-bit platforms this type would have a size of 32 bits, but Inko
   doesn't support 32-bit platforms, so in practise this value is always 64

--- a/docs/source/getting-started/traits.md
+++ b/docs/source/getting-started/traits.md
@@ -146,3 +146,24 @@ It's possible for different traits to define methods with the same name. If a
 type tries to implement such traits, a compile-time error is produced. Inko
 doesn't support renaming of trait methods as part of the implementation, so
 you'll need to find a way to resolve such conflicts yourself.
+
+## Conditional trait implementations
+
+Sometimes we want to implement a trait, but only if additional requirements are
+met. For example, we want to implement `std.cmp.Equal` for `Array` but only if
+its sub values also implement `std.cmp.Equal`. This is done as follows:
+
+```inko
+import std.cmp (Equal)
+
+impl Equal[ref Array[T]] for Array if T: Equal[ref T] {
+  fn pub ==(other: ref Array[T]) -> Bool {
+    ...
+  }
+}
+```
+
+What happens here is that we implement `Equal` over `ref Array[T]`, for any
+`Array[T]` _provided_ that whatever is assigned to `T` also implements
+`Equal[ref T]`. For example, given an `Array[User]`, the `Array.==` method is
+only available if `User` implements `Equal[ref User]`.

--- a/docs/source/references/syntax.md
+++ b/docs/source/references/syntax.md
@@ -265,6 +265,14 @@ class enum Result {
 
 Enum classes can't define regular fields.
 
+### Stack allocated classes
+
+Stack allocated classes are defined using the `inline` keyword:
+
+```inko
+class pub inline Example {}
+```
+
 ### Generic classes
 
 Generic classes are defined like so:

--- a/std/fixtures/diagnostics/casting_value_types.inko
+++ b/std/fixtures/diagnostics/casting_value_types.inko
@@ -1,0 +1,33 @@
+import std.string (ToString)
+
+class inline A {}
+
+impl ToString for A {
+  fn pub to_string -> String {
+    'A'
+  }
+}
+
+class B {}
+
+impl ToString for B {
+  fn pub to_string -> String {
+    'B'
+  }
+}
+
+fn example {
+  '10' as ToString
+  10 as ToString
+  1.0 as ToString
+  A() as ToString
+  B() as ToString
+  A() as UInt64
+  0x4 as Pointer[UInt64] as UInt64
+}
+
+# casting_value_types.inko:20:3 error(invalid-cast): the type 'String' can't be cast to 'ToString'
+# casting_value_types.inko:21:3 error(invalid-cast): the type 'Int' can't be cast to 'ToString'
+# casting_value_types.inko:22:3 error(invalid-cast): the type 'Float' can't be cast to 'ToString'
+# casting_value_types.inko:23:3 error(invalid-cast): the type 'A' can't be cast to 'ToString'
+# casting_value_types.inko:25:3 error(invalid-cast): the type 'A' can't be cast to 'UInt64'

--- a/std/fixtures/diagnostics/default_method_with_bounds.inko
+++ b/std/fixtures/diagnostics/default_method_with_bounds.inko
@@ -28,5 +28,5 @@ fn invalid {
   Box(10).bar
 }
 
-# default_method_with_bounds.inko:27:3 error(invalid-symbol): the method 'foo' exists but isn't available because one or more type parameter bounds aren't met
-# default_method_with_bounds.inko:28:3 error(invalid-symbol): the method 'bar' exists but isn't available because one or more type parameter bounds aren't met
+# default_method_with_bounds.inko:27:11 error(invalid-symbol): the method 'foo' exists but isn't available because one or more type parameter bounds aren't met
+# default_method_with_bounds.inko:28:11 error(invalid-symbol): the method 'bar' exists but isn't available because one or more type parameter bounds aren't met

--- a/std/fixtures/diagnostics/immutable_types_implementing_mutating_methods.inko
+++ b/std/fixtures/diagnostics/immutable_types_implementing_mutating_methods.inko
@@ -1,0 +1,21 @@
+trait Mutate {
+  fn mut foo
+
+  fn mut bar {}
+
+  fn mut baz {}
+
+  fn mut quix {}
+}
+
+class inline A {}
+
+impl Mutate for A {
+  fn mut foo {}
+
+  fn mut quix {}
+}
+
+# immutable_types_implementing_mutating_methods.inko:13:1 error(invalid-implementation): the trait '{}' can't be implemented because it defines one or more mutating methods, and '{}' is an immutable type
+# immutable_types_implementing_mutating_methods.inko:14:3 error(invalid-method): 'A' doesn't support mutating methods because it's an immutable type
+# immutable_types_implementing_mutating_methods.inko:16:3 error(invalid-method): 'A' doesn't support mutating methods because it's an immutable type

--- a/std/fixtures/diagnostics/immutable_types_with_mutating_methods.inko
+++ b/std/fixtures/diagnostics/immutable_types_with_mutating_methods.inko
@@ -1,0 +1,10 @@
+class inline A {
+  fn mut invalid {}
+}
+
+impl String {
+  fn mut invalid {}
+}
+
+# immutable_types_with_mutating_methods.inko:2:3 error(invalid-method): 'A' doesn't support mutating methods because it's an immutable type
+# immutable_types_with_mutating_methods.inko:6:3 error(invalid-method): 'String' doesn't support mutating methods because it's an immutable type

--- a/std/fixtures/diagnostics/inline_enum_definitions.inko
+++ b/std/fixtures/diagnostics/inline_enum_definitions.inko
@@ -1,0 +1,14 @@
+class inline enum Valid {
+  case A(Int, Float)
+}
+
+class inline enum Invalid1 {
+  case A(Int, String)
+}
+
+class inline enum Invalid2 {
+  case A(Int, Array[Int])
+}
+
+# inline_enum_definitions.inko:6:15 error(invalid-type): an 'inline' or 'extern' type is expected, but 'String' is a heap type
+# inline_enum_definitions.inko:10:15 error(invalid-type): an 'inline' or 'extern' type is expected, but 'Array[Int]' is a heap type

--- a/std/fixtures/diagnostics/inline_type_definitions.inko
+++ b/std/fixtures/diagnostics/inline_type_definitions.inko
@@ -1,0 +1,14 @@
+class inline A {}
+
+class pub inline B {}
+
+class inline enum C {}
+
+class pub inline enum D {}
+
+class inline async E {}
+
+class inline extern F {}
+
+# inline_type_definitions.inko:9:20 error(invalid-type): only regular and 'enum' types support the 'inline' attribute
+# inline_type_definitions.inko:11:21 error(invalid-type): only regular and 'enum' types support the 'inline' attribute

--- a/std/fixtures/diagnostics/inline_type_instances.inko
+++ b/std/fixtures/diagnostics/inline_type_instances.inko
@@ -1,0 +1,15 @@
+class inline A[T] {
+  let @value: T
+}
+
+class extern B {
+  let @value: Int
+}
+
+fn example1 {
+  A(value: 42)
+  A(value: B(value: 42))
+  A(value: 'not a stack type')
+}
+
+# inline_type_instances.inko:12:12 error(invalid-type): expected a value of type 'T: inline', found 'String'

--- a/std/fixtures/diagnostics/inline_type_parameters.inko
+++ b/std/fixtures/diagnostics/inline_type_parameters.inko
@@ -1,0 +1,15 @@
+class Example[T: inline] {
+  let @value: T
+}
+
+fn example[T: inline](value: T) {}
+
+fn examples {
+  Example(42)
+  Example([10])
+  example(42)
+  example([10])
+}
+
+# inline_type_parameters.inko:9:11 error(invalid-type): expected a value of type 'T: inline', found 'Array[Int]'
+# inline_type_parameters.inko:11:11 error(invalid-type): expected a value of type 'T: inline', found 'Array[Int]'

--- a/std/fixtures/diagnostics/inline_types_as_mutable_arguments.inko
+++ b/std/fixtures/diagnostics/inline_types_as_mutable_arguments.inko
@@ -1,0 +1,7 @@
+class inline A {
+  let @value: Int
+}
+
+fn example(value: mut A) {}
+
+# inline_types_as_mutable_arguments.inko:5:23 error(invalid-type): mutable borrows of type 'A' are invalid as 'A' is immutable

--- a/std/fixtures/diagnostics/inline_types_with_fields.inko
+++ b/std/fixtures/diagnostics/inline_types_with_fields.inko
@@ -1,0 +1,23 @@
+class inline A {
+  let @value: Int
+}
+
+class inline B {
+  let @value1: A
+  let @value2: C
+}
+
+class extern C {
+  let @value: Int
+}
+
+class inline D[T] {
+  let @value: T
+}
+
+class inline E {
+  let @valid: D[Int]
+  let @invalid: D[String]
+}
+
+# inline_types_with_fields.inko:20:19 error(invalid-type): 'String' can't be assigned to type parameter 'T: inline'

--- a/std/fixtures/diagnostics/inline_types_with_methods.inko
+++ b/std/fixtures/diagnostics/inline_types_with_methods.inko
@@ -1,0 +1,12 @@
+class inline A {
+  fn a {
+    self.test
+  }
+
+  fn move b {
+    self.test
+  }
+}
+
+# inline_types_with_methods.inko:3:5 error(invalid-symbol): the method 'test' isn't defined for type 'A'
+# inline_types_with_methods.inko:7:5 error(invalid-symbol): the method 'test' isn't defined for type 'A'

--- a/std/fixtures/diagnostics/mutating_inline_types.inko
+++ b/std/fixtures/diagnostics/mutating_inline_types.inko
@@ -1,0 +1,11 @@
+class inline A {
+  let @value: Int
+}
+
+fn example {
+  let a = A(value: 1)
+
+  a.value = 2
+}
+
+# mutating_inline_types.inko:8:3 error(invalid-assign): can't assign a new value to field 'value', as its receiver is immutable

--- a/std/fixtures/diagnostics/recursive_classes.inko
+++ b/std/fixtures/diagnostics/recursive_classes.inko
@@ -1,0 +1,66 @@
+class A {
+  let @a: A
+}
+
+class inline B {
+  let @a: Int
+  let @b: Float
+  let @c: Pointer[Int64]
+}
+
+class inline C {
+  let @a: D
+}
+
+class inline D {
+  let @a: Int
+}
+
+class inline E {
+  let @a: E
+}
+
+class inline F {
+  let @a: G[F]
+}
+
+class inline G[T] {
+  let @a: T
+}
+
+class inline H {
+  let @a: I[Int]
+}
+
+class inline I[T] {
+  let @a: T
+  let @b: H
+}
+
+class extern J {
+  let @a: Int64
+}
+
+class extern K {
+  let @a: K
+}
+
+class extern L {
+  let @a: M
+}
+
+class extern M {
+  let @a: L
+}
+
+class extern N {
+  let @a: Pointer[N]
+}
+
+# recursive_classes.inko:19:1 error(invalid-type): 'inline' and 'extern' types can't be recursive
+# recursive_classes.inko:23:1 error(invalid-type): 'inline' and 'extern' types can't be recursive
+# recursive_classes.inko:31:1 error(invalid-type): 'inline' and 'extern' types can't be recursive
+# recursive_classes.inko:35:1 error(invalid-type): 'inline' and 'extern' types can't be recursive
+# recursive_classes.inko:44:1 error(invalid-type): 'inline' and 'extern' types can't be recursive
+# recursive_classes.inko:48:1 error(invalid-type): 'inline' and 'extern' types can't be recursive
+# recursive_classes.inko:52:1 error(invalid-type): 'inline' and 'extern' types can't be recursive

--- a/std/fixtures/diagnostics/type_parameter_bounds.inko
+++ b/std/fixtures/diagnostics/type_parameter_bounds.inko
@@ -1,0 +1,12 @@
+class A[T] {}
+
+impl A if T: mut {}
+
+impl A if T: inline {}
+
+impl A if T: mut + inline {}
+
+impl A if T: inline + mut {}
+
+# type_parameter_bounds.inko:7:20 error(invalid-type): type parameters can't be both 'mut' and 'inline', as 'inline' types are immutable
+# type_parameter_bounds.inko:9:23 error(invalid-type): type parameters can't be both 'mut' and 'inline', as 'inline' types are immutable

--- a/std/fixtures/diagnostics/type_parameter_requirements.inko
+++ b/std/fixtures/diagnostics/type_parameter_requirements.inko
@@ -1,0 +1,10 @@
+class A[T: mut] {}
+
+class B[T: inline] {}
+
+class C[T: mut + inline] {}
+
+class D[T: inline + mut] {}
+
+# type_parameter_requirements.inko:5:18 error(invalid-type): type parameters can't be both 'mut' and 'inline', as 'inline' types are immutable
+# type_parameter_requirements.inko:7:21 error(invalid-type): type parameters can't be both 'mut' and 'inline', as 'inline' types are immutable

--- a/std/fixtures/diagnostics/value_types_passed_to_mutable_arguments.inko
+++ b/std/fixtures/diagnostics/value_types_passed_to_mutable_arguments.inko
@@ -1,0 +1,42 @@
+class inline A {
+  let @value: Int
+}
+
+fn owned[T](value: T) {}
+
+fn mutable_owned[T: mut](value: T) {}
+
+fn mutable_borrow[T: mut](value: mut T) {}
+
+fn immutable_borrow[T](value: ref T) {}
+
+fn example {
+  owned(1)
+  owned(1.0)
+  owned('test')
+  owned(A(1))
+
+  immutable_borrow(1)
+  immutable_borrow(1.0)
+  immutable_borrow('test')
+  immutable_borrow(A(1))
+
+  mutable_owned(1)
+  mutable_owned(1.0)
+  mutable_owned('test')
+  mutable_owned(A(1))
+
+  mutable_borrow(1)
+  mutable_borrow(1.0)
+  mutable_borrow('test')
+  mutable_borrow(A(1))
+}
+
+# value_types_passed_to_mutable_arguments.inko:24:17 error(invalid-type): expected a value of type 'T: mut', found 'Int'
+# value_types_passed_to_mutable_arguments.inko:25:17 error(invalid-type): expected a value of type 'T: mut', found 'Float'
+# value_types_passed_to_mutable_arguments.inko:26:17 error(invalid-type): expected a value of type 'T: mut', found 'String'
+# value_types_passed_to_mutable_arguments.inko:27:17 error(invalid-type): expected a value of type 'T: mut', found 'A'
+# value_types_passed_to_mutable_arguments.inko:29:18 error(invalid-type): expected a value of type 'mut T: mut', found 'Int'
+# value_types_passed_to_mutable_arguments.inko:30:18 error(invalid-type): expected a value of type 'mut T: mut', found 'Float'
+# value_types_passed_to_mutable_arguments.inko:31:18 error(invalid-type): expected a value of type 'mut T: mut', found 'String'
+# value_types_passed_to_mutable_arguments.inko:32:18 error(invalid-type): expected a value of type 'mut T: mut', found 'A'

--- a/std/fixtures/fmt/classes/input.inko
+++ b/std/fixtures/fmt/classes/input.inko
@@ -1,0 +1,51 @@
+class A {
+  let @b: Int
+}
+
+class pub B {
+  let @b: Int
+}
+
+class async C {
+  let @b: Int
+}
+
+class pub async D {
+  let @b: Int
+}
+
+class builtin E {
+  let @b: Int
+}
+
+class enum F {
+  case A(Int)
+}
+
+class pub enum G {
+  case A(Int)
+}
+
+class extern H {
+  let @a: Int
+}
+
+class pub extern I {
+  let @a: Int
+}
+
+class inline J {
+  let @a: Int
+}
+
+class pub inline K {
+  let @a: Int
+}
+
+class L {
+  let @a: Int
+}
+
+class pub M {
+  let @a: Int
+}

--- a/std/fixtures/fmt/classes/output.inko
+++ b/std/fixtures/fmt/classes/output.inko
@@ -1,0 +1,51 @@
+class A {
+  let @b: Int
+}
+
+class pub B {
+  let @b: Int
+}
+
+class async C {
+  let @b: Int
+}
+
+class pub async D {
+  let @b: Int
+}
+
+class builtin E {
+  let @b: Int
+}
+
+class enum F {
+  case A(Int)
+}
+
+class pub enum G {
+  case A(Int)
+}
+
+class extern H {
+  let @a: Int
+}
+
+class pub extern I {
+  let @a: Int
+}
+
+class inline J {
+  let @a: Int
+}
+
+class pub inline K {
+  let @a: Int
+}
+
+class L {
+  let @a: Int
+}
+
+class pub M {
+  let @a: Int
+}

--- a/std/fixtures/fmt/type_parameters/input.inko
+++ b/std/fixtures/fmt/type_parameters/input.inko
@@ -1,0 +1,11 @@
+fn a[P: A] {}
+
+fn b[P: B + A] {}
+
+fn c[P: B + A + mut] {}
+
+fn d[P: B + A + inline] {}
+
+fn e[P: B + A + inline + mut] {}
+
+fn f[P: mut + inline] {}

--- a/std/fixtures/fmt/type_parameters/output.inko
+++ b/std/fixtures/fmt/type_parameters/output.inko
@@ -1,0 +1,11 @@
+fn a[P: A] {}
+
+fn b[P: A + B] {}
+
+fn c[P: mut + A + B] {}
+
+fn d[P: inline + A + B] {}
+
+fn e[P: inline + mut + A + B] {}
+
+fn f[P: inline + mut] {}

--- a/std/src/std/csv.inko
+++ b/std/src/std/csv.inko
@@ -140,7 +140,7 @@ impl Equal[ref ErrorKind] for ErrorKind {
 }
 
 # A type describing the column separator.
-class pub enum Separator {
+class pub inline enum Separator {
   # Columns are separated using a comma (",").
   case Comma
 

--- a/std/src/std/io.inko
+++ b/std/src/std/io.inko
@@ -110,7 +110,7 @@ fn reset_os_error {
 # Unix systems. This enum doesn't define a constructor for every possible error.
 # Instead, we define a constructor for the most commonly used errors, and
 # represent other errors using the `Other` constructor.
-class pub enum Error {
+class pub inline enum Error {
   # The address is already in use.
   case AddressInUse
 

--- a/std/src/std/net/ip.inko
+++ b/std/src/std/net/ip.inko
@@ -43,7 +43,7 @@ fn octets_to_hextet(first: Int, second: Int) -> Int {
 }
 
 # An IPv4 or IPv6 address.
-class pub enum IpAddress {
+class pub inline enum IpAddress {
   # An IPv4 address.
   case V4(Ipv4Address)
 
@@ -169,7 +169,7 @@ class pub enum IpAddress {
 }
 
 impl Equal[ref IpAddress] for IpAddress {
-  fn pub ==(other: ref IpAddress) -> Bool {
+  fn pub inline ==(other: ref IpAddress) -> Bool {
     match self {
       case V4(a) -> {
         match other {
@@ -206,7 +206,7 @@ impl ToString for IpAddress {
 }
 
 impl Clone[IpAddress] for IpAddress {
-  fn pub clone -> IpAddress {
+  fn pub inline clone -> IpAddress {
     match self {
       case V4(ip) -> IpAddress.V4(ip.clone)
       case V6(ip) -> IpAddress.V6(ip.clone)
@@ -221,7 +221,7 @@ impl FormatTrait for IpAddress {
 }
 
 # An IPv6 address.
-class pub Ipv6Address {
+class pub inline Ipv6Address {
   let @a: Int
   let @b: Int
   let @c: Int
@@ -517,7 +517,7 @@ impl Equal[ref Ipv6Address] for Ipv6Address {
   # addr1 == addr2 # => true
   # addr1 == addr3 # => false
   # ```
-  fn pub ==(other: ref Ipv6Address) -> Bool {
+  fn pub inline ==(other: ref Ipv6Address) -> Bool {
     @a == other.a
       and @b == other.b
       and @c == other.c
@@ -639,13 +639,13 @@ impl IntoString for Ipv6Address {
 }
 
 impl Clone[Ipv6Address] for Ipv6Address {
-  fn pub clone -> Ipv6Address {
+  fn pub inline clone -> Ipv6Address {
     Ipv6Address(a: @a, b: @b, c: @c, d: @d, e: @e, f: @f, g: @g, h: @h)
   }
 }
 
 # An IPv4 address.
-class pub Ipv4Address {
+class pub inline Ipv4Address {
   let @a: Int
   let @b: Int
   let @c: Int
@@ -908,7 +908,7 @@ impl Equal[ref Ipv4Address] for Ipv4Address {
   # addr1 == addr2 # => true
   # addr1 == addr3 # => false
   # ```
-  fn pub ==(other: ref Ipv4Address) -> Bool {
+  fn pub inline ==(other: ref Ipv4Address) -> Bool {
     @a == other.a and @b == other.b and @c == other.c and @d == other.d
   }
 }
@@ -938,7 +938,7 @@ impl IntoString for Ipv4Address {
 }
 
 impl Clone[Ipv4Address] for Ipv4Address {
-  fn pub clone -> Ipv4Address {
+  fn pub inline clone -> Ipv4Address {
     Ipv4Address(a: @a, b: @b, c: @c, d: @d)
   }
 }

--- a/std/src/std/net/socket.inko
+++ b/std/src/std/net/socket.inko
@@ -86,7 +86,7 @@ trait RawSocketOperations {
 }
 
 # An IPv4 or IPv6 socket address.
-class pub SocketAddress {
+class pub inline SocketAddress {
   # The IPv4/IPv6 address of this socket address.
   let pub @ip: IpAddress
 
@@ -96,7 +96,7 @@ class pub SocketAddress {
 
 impl Equal[ref SocketAddress] for SocketAddress {
   # Returns `true` if `self` and `other` are the same.
-  fn pub ==(other: ref SocketAddress) -> Bool {
+  fn pub inline ==(other: ref SocketAddress) -> Bool {
     @ip == other.ip and @port == other.port
   }
 }

--- a/std/src/std/range.inko
+++ b/std/src/std/range.inko
@@ -45,12 +45,9 @@ trait pub Range: Contains[Int] + Hash + Format {
 }
 
 # An inclusive range of integers.
-class pub InclusiveRange {
-  # The start value of the range.
-  let pub @start: Int
-
-  # The end value of the range.
-  let pub @end: Int
+class pub inline InclusiveRange {
+  let @start: Int
+  let @end: Int
 
   # Returns a new `InclusiveRange` over the given values.
   fn pub static new(start: Int, end: Int) -> InclusiveRange {
@@ -59,25 +56,25 @@ class pub InclusiveRange {
 }
 
 impl Clone[InclusiveRange] for InclusiveRange {
-  fn pub clone -> InclusiveRange {
+  fn pub inline clone -> InclusiveRange {
     InclusiveRange(start: @start, end: @end)
   }
 }
 
 impl Range for InclusiveRange {
-  fn pub start -> Int {
+  fn pub inline start -> Int {
     @start
   }
 
-  fn pub end -> Int {
+  fn pub inline end -> Int {
     @end
   }
 
-  fn pub inclusive? -> Bool {
+  fn pub inline inclusive? -> Bool {
     true
   }
 
-  fn pub size -> Int {
+  fn pub inline size -> Int {
     if @end >= @start { @end - @start + 1 } else { 0 }
   }
 
@@ -106,7 +103,7 @@ impl Contains[Int] for InclusiveRange {
   # 1.to(10).contains?(5)  # => true
   # 1.to(10).contains?(10) # => true
   # ```
-  fn pub contains?(value: ref Int) -> Bool {
+  fn pub inline contains?(value: ref Int) -> Bool {
     @start <= value and value <= @end
   }
 }
@@ -127,7 +124,7 @@ impl Equal[ref InclusiveRange] for InclusiveRange {
   # ```inko
   # 1.to(10) == 1.to(5) # => false
   # ```
-  fn pub ==(other: ref InclusiveRange) -> Bool {
+  fn pub inline ==(other: ref InclusiveRange) -> Bool {
     @start == other.start and @end == other.end
   }
 }
@@ -148,39 +145,39 @@ impl Format for InclusiveRange {
 }
 
 # An exclusive range of integers.
-class pub ExclusiveRange {
+class pub inline ExclusiveRange {
   # The start value of the range.
-  let pub @start: Int
+  let @start: Int
 
   # The end value of the range.
-  let pub @end: Int
+  let @end: Int
 
   # Returns a new `ExclusiveRange` over the given values.
-  fn pub static new(start: Int, end: Int) -> ExclusiveRange {
+  fn pub inline static new(start: Int, end: Int) -> ExclusiveRange {
     ExclusiveRange(start: start, end: end)
   }
 }
 
 impl Clone[ExclusiveRange] for ExclusiveRange {
-  fn pub clone -> ExclusiveRange {
+  fn pub inline clone -> ExclusiveRange {
     ExclusiveRange(start: @start, end: @end)
   }
 }
 
 impl Range for ExclusiveRange {
-  fn pub start -> Int {
+  fn pub inline start -> Int {
     @start
   }
 
-  fn pub end -> Int {
+  fn pub inline end -> Int {
     @end
   }
 
-  fn pub inclusive? -> Bool {
+  fn pub inline inclusive? -> Bool {
     false
   }
 
-  fn pub size -> Int {
+  fn pub inline size -> Int {
     if @end >= @start { @end - @start } else { 0 }
   }
 
@@ -209,7 +206,7 @@ impl Contains[Int] for ExclusiveRange {
   # 1.until(10).cover?(5)  # => true
   # 1.until(10).cover?(15) # => false
   # ```
-  fn pub contains?(value: ref Int) -> Bool {
+  fn pub inline contains?(value: ref Int) -> Bool {
     @start <= value and value < @end
   }
 }
@@ -230,7 +227,7 @@ impl Equal[ref ExclusiveRange] for ExclusiveRange {
   # ```inko
   # 1.until(10) == 1.until(5) # => false
   # ```
-  fn pub ==(other: ref ExclusiveRange) -> Bool {
+  fn pub inline ==(other: ref ExclusiveRange) -> Bool {
     @start == other.start and @end == other.end
   }
 }

--- a/std/src/std/string.inko
+++ b/std/src/std/string.inko
@@ -19,7 +19,7 @@ import std.ptr
 
 class extern StringResult {
   let @tag: Int
-  let @value: String
+  let @value: Pointer[UInt8]
 }
 
 fn extern inko_string_to_lower(state: Pointer[UInt8], string: String) -> String
@@ -916,7 +916,7 @@ class pub Chars {
 impl Iter[String] for Chars {
   fn pub mut next -> Option[String] {
     match inko_string_chars_next(_INKO.state, @iter) {
-      case { @tag = 0, @value = v } -> Option.Some(v)
+      case { @tag = 0, @value = v } -> Option.Some(v as UInt64 as String)
       case _ -> Option.None
     }
   }

--- a/std/src/std/test.inko
+++ b/std/src/std/test.inko
@@ -648,7 +648,14 @@ class pub Tests {
 
       let got = output.stderr.split('\n').last.or('the process panicked')
 
-      test.failures.push(Failure.new(got, 'the process not to panic'))
+      test.failures.push(
+        Failure(
+          got: got,
+          expected: 'the process not to panic',
+          path: test.path.clone,
+          line: test.line,
+        ),
+      )
     })
   }
 

--- a/std/src/std/time.inko
+++ b/std/src/std/time.inko
@@ -28,6 +28,10 @@ let LEAP_DAYS = [0, 31, 60, 91, 121, 152, 182, 213, 244, 274, 205, 335]
 # year.
 let NORMAL_DAYS = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 204, 334]
 
+fn negative_time_error(time: Int) -> Never {
+  panic("Instant can't represent a negative time (${time})")
+}
+
 # A span of time measured in nanoseconds.
 #
 # A `Duration` can be used to measure the span of time without having to worry
@@ -42,7 +46,7 @@ let NORMAL_DAYS = [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 204, 334]
 # is useful when performing arithmetic on `Duration` objects, as you won't have
 # to worry about overflows. It also lets you represent a duration that goes back
 # in time, i.e. "something that happened 5 seconds ago".
-class pub Duration {
+class pub inline Duration {
   let @nanos: Int
 
   # Creates a new `Duration` from the given number of seconds.
@@ -54,7 +58,7 @@ class pub Duration {
   #
   # Duration.from_secs(10.5)
   # ```
-  fn pub static from_secs[T: ToFloat](secs: ref T) -> Duration {
+  fn pub inline static from_secs[T: ToFloat](secs: ref T) -> Duration {
     Duration((secs.to_float * NANOS_PER_SEC).to_int)
   }
 
@@ -67,7 +71,7 @@ class pub Duration {
   #
   # Duration.from_millis(10)
   # ```
-  fn pub static from_millis[T: ToInt](millis: ref T) -> Duration {
+  fn pub inline static from_millis[T: ToInt](millis: ref T) -> Duration {
     Duration(millis.to_int * MICROS_PER_SEC)
   }
 
@@ -80,7 +84,7 @@ class pub Duration {
   #
   # Duration.from_micros(10)
   # ```
-  fn pub static from_micros[T: ToInt](micros: ref T) -> Duration {
+  fn pub inline static from_micros[T: ToInt](micros: ref T) -> Duration {
     Duration(micros.to_int * MILLIS_PER_SEC)
   }
 
@@ -93,7 +97,7 @@ class pub Duration {
   #
   # Duration.from_nanos(10)
   # ```
-  fn pub static from_nanos[T: ToInt](nanos: ref T) -> Duration {
+  fn pub inline static from_nanos[T: ToInt](nanos: ref T) -> Duration {
     Duration(nanos.to_int)
   }
 
@@ -106,7 +110,7 @@ class pub Duration {
   #
   # Duration.from_secs(5).to_secs # => 5.0
   # ```
-  fn pub to_secs -> Float {
+  fn pub inline to_secs -> Float {
     @nanos.to_float / NANOS_PER_SEC
   }
 
@@ -119,7 +123,7 @@ class pub Duration {
   #
   # Duration.from_secs(5).to_millis # => 5000
   # ```
-  fn pub to_millis -> Int {
+  fn pub inline to_millis -> Int {
     @nanos / MICROS_PER_SEC
   }
 
@@ -132,7 +136,7 @@ class pub Duration {
   #
   # Duration.from_secs(5).to_micros # => 5000000
   # ```
-  fn pub to_micros -> Int {
+  fn pub inline to_micros -> Int {
     @nanos / MILLIS_PER_SEC
   }
 
@@ -145,7 +149,7 @@ class pub Duration {
   #
   # Duration.from_secs(5).to_nanos # => 5000000000
   # ```
-  fn pub to_nanos -> Int {
+  fn pub inline to_nanos -> Int {
     @nanos
   }
 }
@@ -168,43 +172,43 @@ impl ToInstant for Duration {
   #
   # This method panics if the resulting `Instant` is invalid, such as when it's
   # a negative time.
-  fn pub to_instant -> Instant {
+  fn pub inline to_instant -> Instant {
     Instant.new + self
   }
 }
 
 impl Clone[Duration] for Duration {
-  fn pub clone -> Duration {
+  fn pub inline clone -> Duration {
     Duration(@nanos)
   }
 }
 
 impl Add[Duration, Duration] for Duration {
-  fn pub +(other: ref Duration) -> Duration {
+  fn pub inline +(other: ref Duration) -> Duration {
     Duration(@nanos + other.nanos)
   }
 }
 
 impl Subtract[Duration, Duration] for Duration {
-  fn pub -(other: ref Duration) -> Duration {
+  fn pub inline -(other: ref Duration) -> Duration {
     Duration(@nanos - other.nanos)
   }
 }
 
 impl Multiply[Int, Duration] for Duration {
-  fn pub *(other: ref Int) -> Duration {
+  fn pub inline *(other: ref Int) -> Duration {
     Duration(@nanos * other)
   }
 }
 
 impl Compare[Duration] for Duration {
-  fn pub cmp(other: ref Duration) -> Ordering {
+  fn pub inline cmp(other: ref Duration) -> Ordering {
     @nanos.cmp(other.nanos)
   }
 }
 
 impl Equal[ref Duration] for Duration {
-  fn pub ==(other: ref Duration) -> Bool {
+  fn pub inline ==(other: ref Duration) -> Bool {
     @nanos == other.nanos
   }
 }
@@ -435,7 +439,7 @@ class pub DateTime {
 }
 
 impl Clone[DateTime] for DateTime {
-  fn pub clone -> DateTime {
+  fn pub inline clone -> DateTime {
     DateTime(
       year: @year,
       month: @month,
@@ -527,7 +531,7 @@ impl Compare[DateTime] for DateTime {
 }
 
 impl Equal[ref DateTime] for DateTime {
-  fn pub ==(other: ref DateTime) -> Bool {
+  fn pub inline ==(other: ref DateTime) -> Bool {
     @year == other.year
       and @month == other.month
       and @day == other.day
@@ -558,11 +562,11 @@ trait pub ToInstant {
 # tasks such as measuring the execution time of a block of code.
 #
 # An `Instant` can never represent a negative time (e.g. -5).
-class pub Instant {
+class pub inline Instant {
   let @nanos: Int
 
   # Returns a new `Instant` representing the current time.
-  fn pub static new -> Instant {
+  fn pub inline static new -> Instant {
     Instant(inko_time_monotonic(_INKO.state) as Int)
   }
 
@@ -587,7 +591,7 @@ class pub Instant {
   #
   # start.elapsed.to_secs >= 1.0 # => true
   # ```
-  fn pub elapsed -> Duration {
+  fn pub inline elapsed -> Duration {
     Duration(inko_time_monotonic(_INKO.state) as Int - @nanos)
   }
 
@@ -604,63 +608,63 @@ class pub Instant {
   #
   # time.remaining # => Duration.from_secs(5)
   # ```
-  fn pub remaining -> Duration {
+  fn pub inline remaining -> Duration {
     Duration(@nanos - (inko_time_monotonic(_INKO.state) as Int))
   }
 }
 
 impl ToInstant for Instant {
-  fn pub to_instant -> Instant {
+  fn pub inline to_instant -> Instant {
     clone
   }
 }
 
 impl Clone[Instant] for Instant {
-  fn pub clone -> Instant {
+  fn pub inline clone -> Instant {
     Instant(@nanos)
   }
 }
 
 impl ToInt for Instant {
-  fn pub to_int -> Int {
+  fn pub inline to_int -> Int {
     @nanos.to_int
   }
 }
 
 impl ToFloat for Instant {
-  fn pub to_float -> Float {
+  fn pub inline to_float -> Float {
     @nanos.to_float
   }
 }
 
 impl Add[Duration, Instant] for Instant {
-  fn pub +(other: ref Duration) -> Instant {
+  fn pub inline +(other: ref Duration) -> Instant {
     let nanos = @nanos + other.nanos
 
-    if nanos < 0 { panic("Instant can't represent a negative time (${nanos})") }
+    if nanos < 0 { negative_time_error(nanos) }
 
     Instant(nanos)
   }
 }
 
 impl Subtract[Duration, Instant] for Instant {
-  fn pub -(other: ref Duration) -> Instant {
+  fn pub inline -(other: ref Duration) -> Instant {
     let nanos = @nanos - other.nanos
 
-    if nanos < 0 { panic("Instant can't represent a negative time (${nanos})") }
+    if nanos < 0 { negative_time_error(nanos) }
 
     Instant(nanos)
   }
 }
 
 impl Compare[Instant] for Instant {
-  fn pub cmp(other: ref Instant) -> Ordering {
+  fn pub inline cmp(other: ref Instant) -> Ordering {
     @nanos.cmp(other.nanos)
   }
 }
 
 impl Equal[ref Instant] for Instant {
-  fn pub ==(other: ref Instant) -> Bool {
+  fn pub inline ==(other: ref Instant) -> Bool {
     @nanos == other.nanos
   }
 }

--- a/std/test/compiler/test_extern_types.inko
+++ b/std/test/compiler/test_extern_types.inko
@@ -1,0 +1,17 @@
+import std.test (Tests)
+
+class extern Example {
+  let @a: Int
+  let @b: Int
+}
+
+fn pub tests(t: mut Tests) {
+  t.test('extern types can be used in generic contexts', fn (t) {
+    t.true(
+      match Option.Some(Example(a: 10, b: 20)) {
+        case Some({ @a = 10, @b = 20 }) -> true
+        case _ -> false
+      },
+    )
+  })
+}

--- a/std/test/compiler/test_inline_types.inko
+++ b/std/test/compiler/test_inline_types.inko
@@ -1,0 +1,83 @@
+import std.string (ToString)
+import std.test (Tests)
+
+class inline Example[A, B] {
+  let @a: A
+  let @b: B
+}
+
+impl ToString for Example if A: ToString, B: ToString {
+  fn pub to_string -> String {
+    @a.to_string + @b.to_string
+  }
+}
+
+fn to_string[T: ToString](value: T) -> String {
+  value.to_string
+}
+
+class inline enum Enum[A, B] {
+  case A(Example[A, B])
+  case B(Int)
+}
+
+fn pub tests(t: mut Tests) {
+  t.test('inline types can be used in generic contexts', fn (t) {
+    t.true(
+      match Option.Some(Example(a: 10, b: 20)) {
+        case Some({ @a = 10, @b = 20 }) -> true
+        case _ -> false
+      },
+    )
+  })
+
+  # This is just a simple smoke test to make sure field sizes and offsets are
+  # correct for the different specializations.
+  t.test('Generic inline types are specialized correctly', fn (t) {
+    let a = Example(a: 10, b: 20)
+    let b = Example(a: 1.0, b: 2.0)
+    let c = Enum.A(Example(a: 100, b: 200))
+    let d: Enum[Int32, Int] = Enum.B(42)
+
+    t.equal(a.a, 10)
+    t.equal(a.b, 20)
+    t.equal(b.a, 1.0)
+    t.equal(b.b, 2.0)
+    t.true(
+      match c {
+        case A({ @a = 100, @b = 200 }) -> true
+        case _ -> false
+      },
+    )
+    t.true(
+      match d {
+        case B(42) -> true
+        case _ -> false
+      },
+    )
+  })
+
+  t.test('Inline types are copied when they are moved', fn (t) {
+    let a = Example(a: 10, b: 20)
+    let b = a
+
+    t.equal(a.a, 10)
+    t.equal(a.b, 20)
+    t.equal(b.a, 10)
+    t.equal(b.b, 20)
+  })
+
+  t.test('Closures capture inline values by copying them', fn (t) {
+    let a = Example(a: 10, b: 20)
+    let f1 = fn { t.equal(a.b, 20) }
+    let f2 = fn move { t.equal(a.b, 20) }
+
+    f1.call
+    f2.call
+    t.equal(a.b, 20)
+  })
+
+  t.test('Inline types support method calls in generic contexts', fn (t) {
+    t.equal(to_string(Example(a: 10, b: 20)), '1020')
+  })
+}

--- a/std/test/std/test_array.inko
+++ b/std/test/std/test_array.inko
@@ -97,15 +97,16 @@ fn pub tests(t: mut Tests) {
   t.test('Array.opt', fn (t) {
     let vals = [10, 20, 30]
 
-    t.equal(vals.opt(1), Option.Some(ref 20))
+    t.equal(vals.opt(1), Option.Some(20))
     t.equal(vals.opt(5), Option.None)
     t.equal(vals.opt(-5), Option.None)
   })
 
   t.test('Array.opt_mut', fn (t) {
-    let vals = [10, 20, 30]
+    let vals = [(1, 2), (2, 3), (3, 4)]
+    let exp = (2, 3)
 
-    t.equal(vals.opt_mut(1), Option.Some(mut 20))
+    t.equal(vals.opt_mut(1), Option.Some(mut exp))
     t.equal(vals.opt_mut(5), Option.None)
     t.equal(vals.opt_mut(-5), Option.None)
   })
@@ -131,13 +132,15 @@ fn pub tests(t: mut Tests) {
   t.test('Array.iter', fn (t) {
     let vals = [10, 20, 30]
 
-    t.equal(vals.iter.to_array, [ref 10, ref 20, ref 30])
+    t.equal(vals.iter.to_array, [10, 20, 30])
   })
 
   t.test('Array.iter_mut', fn (t) {
-    let vals = [10, 20, 30]
+    let vals = [(1, 2), (2, 3)]
+    let a = (1, 2)
+    let b = (2, 3)
 
-    t.equal(vals.iter_mut.to_array, [mut 10, mut 20, mut 30])
+    t.equal(vals.iter_mut.to_array, [mut a, mut b])
   })
 
   t.test('Array.into_iter', fn (t) {
@@ -149,7 +152,7 @@ fn pub tests(t: mut Tests) {
   t.test('Array.reverse_iter', fn (t) {
     let vals = [10, 20, 30]
 
-    t.equal(vals.reverse_iter.to_array, [ref 30, ref 20, ref 10])
+    t.equal(vals.reverse_iter.to_array, [30, 20, 10])
   })
 
   t.test('Array.append', fn (t) {
@@ -221,9 +224,13 @@ fn pub tests(t: mut Tests) {
 
   t.panic('Array.get with an invalid index', fn { [10].get(1) })
 
-  t.test('Array.get_mut', fn (t) { t.equal([10].get_mut(0), 10) })
+  t.test('Array.get_mut', fn (t) {
+    let exp = (1, 2)
 
-  t.panic('Array.get_mut with an invalid index', fn { [10].get_mut(1) })
+    t.equal([(1, 2)].get_mut(0), mut exp)
+  })
+
+  t.panic('Array.get_mut with an invalid index', fn { [(1, 2)].get_mut(1) })
 
   t.test('Array.set', fn (t) {
     let count = Counter.new
@@ -295,8 +302,10 @@ fn pub tests(t: mut Tests) {
   })
 
   t.test('Array.last_mut', fn (t) {
-    t.equal([].last_mut as Option[Int], Option.None)
-    t.equal([10, 20].last_mut, Option.Some(20))
+    let exp = (2, 3)
+
+    t.equal(([] as Array[(Int, Int)]).last_mut, Option.None)
+    t.equal([(1, 2), (2, 3)].last_mut, Option.Some(mut exp))
   })
 
   t.test('Array.reserve', fn (t) {

--- a/std/test/std/test_deque.inko
+++ b/std/test/std/test_deque.inko
@@ -3,7 +3,7 @@ import std.test (Tests)
 
 fn pub tests(t: mut Tests) {
   t.test('Deque.new', fn (t) {
-    let q = Deque.new
+    let q: Deque[Int] = Deque.new
 
     t.equal(q.size, 0)
     t.equal(q.capacity, 0)
@@ -12,7 +12,7 @@ fn pub tests(t: mut Tests) {
   })
 
   t.test('Deque.with_capacity', fn (t) {
-    let q = Deque.with_capacity(4)
+    let q: Deque[Int] = Deque.with_capacity(4)
 
     t.equal(q.size, 0)
     t.equal(q.capacity, 4)
@@ -143,12 +143,15 @@ fn pub tests(t: mut Tests) {
 
   t.test('Deque.iter_mut', fn (t) {
     let q = Deque.new
+    let a = (1, 0)
+    let b = (2, 0)
+    let c = (3, 0)
 
-    q.push_back(20)
-    q.push_back(30)
-    q.push_front(10)
+    q.push_back((2, 0))
+    q.push_back((3, 0))
+    q.push_front((1, 0))
 
-    t.equal(q.iter_mut.to_array, [10, 20, 30])
+    t.equal(q.iter_mut.to_array, [mut a, mut b, mut c])
   })
 
   t.test('Deque.into_iter', fn (t) {
@@ -194,10 +197,11 @@ fn pub tests(t: mut Tests) {
 
   t.test('Deque.opt_mut', fn (t) {
     let q = Deque.new
+    let exp = (1, 0)
 
-    q.push_back(10)
+    q.push_back((1, 0))
 
-    t.equal(q.opt_mut(0), Option.Some(10))
+    t.equal(q.opt_mut(0), Option.Some(mut exp))
     t.equal(q.opt_mut(1), Option.None)
   })
 }

--- a/std/test/std/test_iter.inko
+++ b/std/test/std/test_iter.inko
@@ -268,15 +268,15 @@ fn pub tests(t: mut Tests) {
   })
 
   t.test('Peekable.peek_mut with an iterator with values', fn (t) {
-    let vals = [1, 2, 3]
+    let vals = [(1, 0), (2, 0), (3, 0)]
     let iter = vals.iter_mut.peekable
 
-    t.equal(iter.peek_mut, Option.Some(1))
-    t.equal(iter.peek_mut, Option.Some(1))
-    t.equal(iter.next, Option.Some(1))
-    t.equal(iter.peek_mut, Option.Some(2))
-    t.equal(iter.next, Option.Some(2))
-    t.equal(iter.next, Option.Some(3))
+    t.equal(iter.peek_mut, Option.Some(mut (1, 0)))
+    t.equal(iter.peek_mut, Option.Some(mut (1, 0)))
+    t.equal(iter.next, Option.Some(mut (1, 0)))
+    t.equal(iter.peek_mut, Option.Some(mut (2, 0)))
+    t.equal(iter.next, Option.Some(mut (2, 0)))
+    t.equal(iter.next, Option.Some(mut (3, 0)))
     t.equal(iter.next, Option.None)
     t.equal(iter.peek_mut, Option.None)
   })

--- a/std/test/std/test_map.inko
+++ b/std/test/std/test_map.inko
@@ -142,10 +142,10 @@ fn pub tests(t: mut Tests) {
   t.test('Map.opt_mut', fn (t) {
     let map = Map.new
 
-    map.set('name', 'Alice')
+    map.set('foo', (1, 0))
 
-    t.equal(map.opt_mut('name'), Option.Some(mut 'Alice'))
-    t.equal(map.opt_mut('city'), Option.None)
+    t.equal(map.opt_mut('foo'), Option.Some(mut (1, 0)))
+    t.equal(map.opt_mut('bar'), Option.None)
   })
 
   t.test('Map.entry', fn (t) {

--- a/std/test/std/test_option.inko
+++ b/std/test/std/test_option.inko
@@ -11,10 +11,11 @@ fn pub tests(t: mut Tests) {
   })
 
   t.test('Option.as_mut', fn (t) {
-    let a = Option.Some('thing')
-    let b: Option[String] = Option.None
+    let a = Option.Some((1, 0))
+    let b: Option[(Int, Int)] = Option.None
+    let exp = (1, 0)
 
-    t.equal(a.as_mut, Option.Some(mut 'thing'))
+    t.equal(a.as_mut, Option.Some(mut exp))
     t.equal(b.as_mut, Option.None)
   })
 

--- a/types/src/resolve.rs
+++ b/types/src/resolve.rs
@@ -209,7 +209,7 @@ impl<'a> TypeResolver<'a> {
                     return Either::Left(id);
                 }
 
-                let mut args = ins.type_arguments(self.db).clone();
+                let mut args = ins.type_arguments(self.db).unwrap().clone();
 
                 self.resolve_arguments(&mut args);
 
@@ -224,7 +224,7 @@ impl<'a> TypeResolver<'a> {
                     return Either::Left(id);
                 }
 
-                let mut args = ins.type_arguments(self.db).clone();
+                let mut args = ins.type_arguments(self.db).unwrap().clone();
 
                 self.resolve_arguments(&mut args);
 
@@ -746,7 +746,7 @@ mod tests {
 
         let arg = match resolve(&mut db, &args, &bounds, input) {
             TypeRef::Owned(TypeId::ClassInstance(ins)) => {
-                ins.type_arguments(&db).get(array_param).unwrap()
+                ins.type_arguments(&db).unwrap().get(array_param).unwrap()
             }
             _ => TypeRef::Unknown,
         };
@@ -777,7 +777,7 @@ mod tests {
 
         let arg = match resolve(&mut db, &args, &bounds, input) {
             TypeRef::Owned(TypeId::ClassInstance(ins)) => {
-                ins.type_arguments(&db).get(array_param).unwrap()
+                ins.type_arguments(&db).unwrap().get(array_param).unwrap()
             }
             _ => TypeRef::Unknown,
         };
@@ -802,7 +802,7 @@ mod tests {
 
         let arg = match resolve(&mut db, &args, &bounds, input) {
             TypeRef::Owned(TypeId::TraitInstance(ins)) => {
-                ins.type_arguments(&db).get(trait_param).unwrap()
+                ins.type_arguments(&db).unwrap().get(trait_param).unwrap()
             }
             _ => TypeRef::Unknown,
         };


### PR DESCRIPTION
This adds support for `inline` types. Such types are immutable value types that are copied upon being moved, and are allocated on the stack without an object header.

## TODO

Initial implementation:

- [x] Replace `ClassKind::Inline` with just a flag on `Class`, making it easier to combine with other class kinds (e.g. `Tuple`) without the need for a ton of constructors
- [x] Disallow recursive `inline` types
  - This can be determined by looking at the definition only. For generic types one has to be able to construct the type in the first place, which isn't possible (code wise) if it's infinite.
- [x] Disallow `Drop` implementations for `inline` types
  - If we allow this, we'd end up calling destructors for every copy and that gets expensive fast. It's also redundant since `inline` types are restricted to types that we can trivially copy around
- [x] Don't call droppers for `inline` types since this is redundant
- [x] Don't generate droppers for `inline` types since they'll never be used
- [x] Merge `TypeRef::is_permanent` into `TypeRef::is_stack_allocated`, as the former is now redundant
- [x] Ensure that type parameter bounds inherit the `mut` and `inline` properties of the original parameter
- [x] Ensure that all field types of an `inline` type are also `inline` (`String` won't be allowed, at least for now I think)
- [x] Ensure that the struct size logic in `compiler::llvm::layouts::Layouts` handles `inline` types correctly. 
  - This depends on the order in which types are defined, likely requiring a different strategy than the one we use at the moment.
  - We might need some sort of work list approach?
- [x] Add the `TypeParameter::inline` field and set this to `true` for any type parameter defined on an `inline` type
- [x] When passing types to an `inline` type parameter, only allow this if the passed type is also an `inline` type
- [x] Support `class inline enum`? This might not be useful if we infer `enum` types as `inline`
- [x] Add support for specializing `inline` (dedicated) types
  - Add `Shape::Custom(ClassInstance)`
  - Make sure we generate a stable/deterministic name for these shapes, regardless of ordering
  - Make sure static dispatch is used for these types when used in generics
  - This means we can also allow `extern` types in generics
  - We should probably just hash the shape identifiers using BLAKE3, ensuring we don't end up with gigantic symbol names (this data is stripped from stack traces anyway)
  - `Shape` implements `Eq` and `Hash`, but that isn't reliable for `ClassInstance` since different occurrences of e.g. `Option[Foo]` use a different `type_arguments` ID
- [x] Make `inline` types immutable and disallow `fn mut` methods
  - Allowing mutation introduces a lot of compiler complexity I'm really not happy with, and requires rewriting part of the generated code post specialization due to how closures capture data
  - `fn` and `fn move` methods expose `self` as `T` (owned)
- [x] The changes in this PR somehow result in values being dropped twice, fix that
- [x] Ensure that `ref expr` and `mut expr` just return the target register when the value is an `inline` type
- [x] Ensure closures correctly capture `inline` values by value
- [x] Include an extra identifier in symbol names for `inline` classes, such that if the `inline` state changes (e.g. through inference in a future setup), we automatically take this into account for object file caching
- [x] Ensure that flagging `inline` types as moved is a noop (i.e. `move R₁` does nothing if `R₁` contains stack data)
- [x] Ensure that `inline` types are sendable
- [x] Add tests to assert that casting `inline` types to traits fails
- [x] Figure out why marking `std.net.socket.SocketAddress` as `inline` causes an invalid `free()`
  - https://github.com/inko-lang/inko/pull/778#issuecomment-2492165927: it's likely due to type sizes not being calculated in the right order
  - This is indeed the issue. Instead of first processing regular classes and then inline classes, we need a work list approach for all
- [x] Fix macOS ARM64 CI failures
  - This is because we don't handle the ARM64 ABI correctly: structs larger than 16 bytes are passed as a pointer argument (see [B.4](https://github.com/ARM-software/abi-aa/blob/2982a9f3b512a5bfdc9e3fea5d3b298f9165c36b/aapcs64/aapcs64.rst#parameter-passing-rules))
  - For x86-64, it seems clang uses a pointer combined with `byval`
  - When loading constructor fields into registers, we use the size of the largest value and not of the one that we just loaded. This results in nonsensical data being written to the stack.
    - `extractvalue` just uses the type of the field its loading, rather than `load` which takes a type, so we need to bitcast things
- [x] Add support for explicit `T: inline`, otherwise you can't define e.g. a `map` that takes a `T` from `self` that happens to be `T: inline` and map that to `R: inline`
- [x] Disallow casting `inline` types to anything (e.g. `UInt64`) because that doesn't make sense for data on the stack

## Verification:

- [x] Verify the generated LLVM is correct
- [x] Update documentation
  - [x] `class inline`
  - [x] `T: inline`
  - [x] Discuss the ABI somewhere in the design section
- [x] Update idoc accordingly