### PR TITLE
Fix DateTime millisecond parsing

### DIFF
--- a/std/src/std/bytes/parsers.inko
+++ b/std/src/std/bytes/parsers.inko
@@ -59,7 +59,7 @@ fn digits[T: Bytes](
 ) -> Option[(Int, Int)] {
   let mut idx = start
   let mut num = 0
-  let max = min(limit + 1, input.size)
+  let max = min(start + limit, input.size)
 
   while idx < max {
     let byte = input.get(idx).or_panic

--- a/std/test/std/test_time.inko
+++ b/std/test/std/test_time.inko
@@ -532,6 +532,7 @@ fn pub tests(t: mut Tests) {
         '%A, %B %d, %Y',
         Option.Some((2024, 12, 14, 0, 0, 0, 0, 0)),
       ),
+      ('12:30:05.123', '%H:%M:%S%f', Option.Some((0, 1, 1, 12, 30, 05, 0, 123_000_000))),
     ]
 
     for rule in tests {


### PR DESCRIPTION
Milliseconds wouldn't parse if after other sequences:

```
Stdout.new.print(fmt(DateTime.parse("30:00", "%M:%S", Locale.new)))
Stdout.new.print(fmt(DateTime.parse(".123", "%f", Locale.new)))
Stdout.new.print(fmt(DateTime.parse("30:00.123", "%M:%S%f", Locale.new)))
```

Before:
```
Some(0000-01-01 00:30:00 UTC)
Some(0000-01-01 00:00:00.123 UTC)
None
```

After:
```
Some(0000-01-01 00:30:00 UTC)
Some(0000-01-01 00:00:00.123 UTC)
Some(0000-01-01 00:30:00.123 UTC)
```