### PR TITLE
Array.append: directly coppy data for better performance

### DIFF
--- a/std/src/std/array.inko
+++ b/std/src/std/array.inko
@@ -463,7 +463,18 @@ type builtin Array[T] {
   # numbers.size # => 5
   # ```
   fn pub mut append(other: Array[T]) {
-    for v in other { push(v) }
+    if other.size == 0 { return }
+
+    let missing_capacity = (size + other.size) - capacity
+    if missing_capacity > 0 { reserve(missing_capacity) }
+
+    let from_addr = other.address_of(0)
+    let to_addr = address_of(size)
+    alloc.copy(from_addr, to_addr, other.size)
+    @size += other.size
+
+    # we just moved all this stuff, make sure `other` doesn't drop it
+    other.size = 0
   }
 
   # Returns the number of values in `self`.

--- a/std/src/std/array.inko
+++ b/std/src/std/array.inko
@@ -463,15 +463,16 @@ type builtin Array[T] {
   # numbers.size # => 5
   # ```
   fn pub mut append(other: Array[T]) {
-    if other.size == 0 { return }
+    let len = other.size
 
-    let missing_capacity = (size + other.size) - capacity
-    if missing_capacity > 0 { reserve(missing_capacity) }
+    if len == 0 { return }
 
-    let from_addr = other.address_of(0)
-    let to_addr = address_of(size)
-    alloc.copy(from_addr, to_addr, other.size)
-    @size += other.size
+    reserve_exact(len)
+
+    let tail = ptr.add(@buffer, @size)
+
+    alloc.copy(other.pointer, tail, len)
+    @size += len
 
     # we just moved all this stuff, make sure `other` doesn't drop it
     other.size = 0


### PR DESCRIPTION
Also avoids letting the source array drop said data

Fixes #830 