### PR TITLE
`StringBuffer`: replace to_string with into_string

### DIFF
--- a/compiler/src/hir.rs
+++ b/compiler/src/hir.rs
@@ -12,7 +12,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use types::{
     ARRAY_INTERNAL_NAME, ARRAY_PUSH, ARRAY_WITH_CAPACITY,
-    STRING_BUFFER_INTERNAL_NAME, STRING_BUFFER_PUSH, STRING_BUFFER_TO_STRING,
+    STRING_BUFFER_INTERNAL_NAME, STRING_BUFFER_INTO_STRING, STRING_BUFFER_PUSH,
     STRING_BUFFER_WITH_CAPACITY, TO_STRING_METHOD,
 };
 
@@ -2286,7 +2286,7 @@ impl<'a> LowerToHir<'a> {
                 // buf.into_string
                 body.push(Expression::call(
                     var_ref,
-                    STRING_BUFFER_TO_STRING,
+                    STRING_BUFFER_INTO_STRING,
                     Vec::new(),
                     node.location,
                 ));
@@ -5781,7 +5781,7 @@ mod tests {
                     ),
                     Expression::call(
                         Expression::identifier_ref(STR_BUF_VAR, cols(8, 16)),
-                        STRING_BUFFER_TO_STRING,
+                        STRING_BUFFER_INTO_STRING,
                         Vec::new(),
                         cols(8, 16)
                     )

--- a/std/src/std/json.inko
+++ b/std/src/std/json.inko
@@ -1581,9 +1581,9 @@ type pub Generator {
   #
   # Generator.new(indent: 2).generate(Json.Array([Json.Int(1)])) # => '[1]'
   # ```
-  fn pub mut generate(value: ref Json) -> String {
+  fn pub move generate(value: ref Json) -> String {
     generate_value(value)
-    @buffer.to_string
+    @buffer.into_string
   }
 
   fn mut generate_value(value: ref Json) {

--- a/std/src/std/net/ip.inko
+++ b/std/src/std/net/ip.inko
@@ -626,7 +626,7 @@ impl ToString for Ipv6Address {
         }
       }
 
-      return buffer.to_string
+      return buffer.into_string
     }
 
     let a = @a.format(format)

--- a/std/src/std/optparse.inko
+++ b/std/src/std/optparse.inko
@@ -160,7 +160,7 @@ import std.clone (Clone)
 import std.cmp (Equal)
 import std.fmt (Format, Formatter)
 import std.iter (Iter, Stream)
-import std.string (StringBuffer, ToString)
+import std.string (IntoString, StringBuffer, ToString)
 
 let INDENT = '  '
 let HYPHEN = 45
@@ -950,7 +950,7 @@ type pub Help {
   #
   # Help.new('ls').usage('[OPTIONS]')
   # ```
-  fn pub mut usage(value: String) -> mut Help {
+  fn pub move usage(value: String) -> Help {
     @usage = value
     self
   }
@@ -964,7 +964,7 @@ type pub Help {
   #
   # Help.new('ls').section('Examples')
   # ```
-  fn pub mut section(name: String) -> mut Help {
+  fn pub move section(name: String) -> Help {
     @lines.push('\n')
     @lines.push(name)
     @lines.push(':\n\n')
@@ -982,7 +982,7 @@ type pub Help {
   #
   # Help.new('ls').section('Examples').line('ls # Show files and folders')
   # ```
-  fn pub mut line(value: String) -> mut Help {
+  fn pub move line(value: String) -> Help {
     @lines.push(INDENT)
     @lines.push(value)
     @lines.push('\n')
@@ -1001,7 +1001,7 @@ type pub Help {
   #
   # Help.new('ls').description('List files and folders')
   # ```
-  fn pub mut description(value: String) -> mut Help {
+  fn pub move description(value: String) -> Help {
     @description = value
     self
   }
@@ -1019,15 +1019,15 @@ type pub Help {
   #
   # Help.new('ls').options(opts)
   # ```
-  fn pub mut options(value: ref Options) -> mut Help {
+  fn pub move options(value: ref Options) -> Help {
     @lines.push(value.to_string)
     @lines.push('\n')
     self
   }
 }
 
-impl ToString for Help {
-  fn pub to_string -> String {
+impl IntoString for Help {
+  fn pub move into_string -> String {
     let out = StringBuffer.from_array(['Usage: ', @name, ' ', @usage, '\n'])
 
     if @description.size > 0 {
@@ -1036,7 +1036,7 @@ impl ToString for Help {
       out.push('\n')
     }
 
-    out.push(@lines.to_string)
+    out.push(@lines.into_string)
     out.into_string
   }
 }

--- a/std/src/std/string.inko
+++ b/std/src/std/string.inko
@@ -167,7 +167,7 @@ type builtin String {
       buff
     })
 
-    result.to_string
+    result.into_string
   }
 
   # Slices `self` into a slice of bytes using a _byte_ range from `start` until
@@ -991,8 +991,8 @@ type pub inline StringBuffer {
   }
 }
 
-impl ToString for StringBuffer {
-  # Generates a `String` using the current contents of the buffer.
+impl IntoString for StringBuffer {
+  # Generates a `String` by consuming the buffer
   #
   # # Examples
   #
@@ -1006,9 +1006,9 @@ impl ToString for StringBuffer {
   # buffer.push('hello ')
   # buffer.push('world')
   #
-  # buffer.to_string # => 'hello world'
+  # buffer.into_string # => 'hello world'
   # ```
-  fn pub to_string -> String {
+  fn pub move into_string -> String {
     if @strings.empty? { return '' }
 
     let mut total = 0
@@ -1034,11 +1034,5 @@ impl ToString for StringBuffer {
 
     alloc.write(byte: 0, to: ptr.add(buf, total), size: 1)
     String(ptr: buf, size: total)
-  }
-}
-
-impl IntoString for StringBuffer {
-  fn pub move into_string -> String {
-    to_string
   }
 }

--- a/std/test/std/test_optparse.inko
+++ b/std/test/std/test_optparse.inko
@@ -559,27 +559,30 @@ fn pub tests(t: mut Tests) {
   })
 
   t.test('Help.new', fn (t) {
-    t.equal(Help.new('a').to_string, 'Usage: a [OPTIONS]\n')
+    t.equal(Help.new('a').into_string, 'Usage: a [OPTIONS]\n')
   })
 
   t.test('Help.usage', fn (t) {
-    t.equal(Help.new('a').usage('[CMD]').to_string, 'Usage: a [CMD]\n')
+    t.equal(Help.new('a').usage('[CMD]').into_string, 'Usage: a [CMD]\n')
   })
 
   t.test('Help.section', fn (t) {
     t.equal(
-      Help.new('a').section('Examples').to_string,
+      Help.new('a').section('Examples').into_string,
       'Usage: a [OPTIONS]\n\nExamples:\n\n',
     )
   })
 
   t.test('Help.line', fn (t) {
-    t.equal(Help.new('a').line('foo').to_string, 'Usage: a [OPTIONS]\n  foo\n')
+    t.equal(
+      Help.new('a').line('foo').into_string,
+      'Usage: a [OPTIONS]\n  foo\n',
+    )
   })
 
   t.test('Help.description', fn (t) {
     t.equal(
-      Help.new('a').description('foo').to_string,
+      Help.new('a').description('foo').into_string,
       'Usage: a [OPTIONS]\n\nfoo\n',
     )
   })
@@ -590,7 +593,7 @@ fn pub tests(t: mut Tests) {
     opts.flag('h', 'help', 'Show this help message')
 
     t.equal(
-      Help.new('a').options(opts).to_string,
+      Help.new('a').options(opts).into_string,
       'Usage: a [OPTIONS]\n  -h, --help    Show this help message\n',
     )
   })
@@ -609,7 +612,7 @@ fn pub tests(t: mut Tests) {
       .line('bar')
       .section('Options')
       .options(opts)
-      .to_string
+      .into_string
 
     t.equal(
       help,

--- a/std/test/std/test_string.inko
+++ b/std/test/std/test_string.inko
@@ -520,16 +520,6 @@ fn pub tests(t: mut Tests) {
     t.equal(buf.size, 1)
   })
 
-  t.test('StringBuffer.to_string', fn (t) {
-    let buf = StringBuffer.new
-
-    t.equal(buf.to_string, '')
-    buf.push('a')
-    buf.push('😃')
-    buf.push('b')
-    t.equal(buf.to_string, 'a😃b')
-  })
-
   t.test('StringBuffer.into_string', fn (t) {
     let buf = StringBuffer.new
 

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -97,7 +97,7 @@ pub const STRING_BUFFER_TYPE: &str = "StringBuffer";
 pub const STRING_BUFFER_WITH_CAPACITY: &str = "with_capacity";
 pub const STRING_BUFFER_PUSH: &str = "push";
 pub const STRING_BUFFER_INTERNAL_NAME: &str = "$StringBuffer";
-pub const STRING_BUFFER_TO_STRING: &str = "to_string";
+pub const STRING_BUFFER_INTO_STRING: &str = "into_string";
 
 /// The name of the pseudo field used to deference a pointer.
 pub const DEREF_POINTER_FIELD: &str = "0";


### PR DESCRIPTION
Also replace all uses within the standard library and remove its test.
The compiler now emits `into_string()` when doing string interpolation.
Preparing for rewriting `StringBuffer` in a way which will remove this method.

Changelog: changed
