### PR TITLE
Fix broken link in CONTRIBUTING.md and outdated use of TcpClient.new in TLS examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 # Contributing
 
 Our contributing guidelines can be found in [the Inko
-manual](https://docs.inko-lang.org/manual/main/guides/contributing/).
+manual](https://docs.inko-lang.org/manual/latest/references/contributing/).

--- a/std/src/std/net/tls.inko
+++ b/std/src/std/net/tls.inko
@@ -314,7 +314,7 @@ impl Clone for ClientConfig {
 #   .new(ips: [IpAddress.v4(127, 0, 0, 1)], port: 9000)
 #   .or_panic_with('failed to connect to the server')
 # let client = Client
-#   .new(socket, conf, name: 'localhost')
+#   .new(sock, conf, name: 'localhost')
 #   .or_panic_with('the server name is invalid')
 #
 # client.write('ping').or_panic_with('failed to write the message')

--- a/std/src/std/net/tls.inko
+++ b/std/src/std/net/tls.inko
@@ -311,7 +311,7 @@ impl Clone for ClientConfig {
 #
 # let conf = ClientConfig.new
 # let sock = TcpClient
-#   .new(ip: IpAddress.v4(127, 0, 0, 1), port: 9000)
+#   .new(ips: [IpAddress.v4(127, 0, 0, 1)], port: 9000)
 #   .or_panic_with('failed to connect to the server')
 # let client = Client
 #   .new(socket, conf, name: 'localhost')
@@ -356,7 +356,7 @@ type pub Client[T: mut + RawSocketOperations] {
   #
   # let conf = ClientConfig.new
   # let sock = TcpClient
-  #   .new(ip: IpAddress.v4(127, 0, 0, 1), port: 9000)
+  #   .new(ips: [IpAddress.v4(127, 0, 0, 1)], port: 9000)
   #   .or_panic_with('failed to connect to the server')
   #
   # Client


### PR DESCRIPTION
3 fixes in documentation have been done:
1. Fix broken link in CONTRIBUTING.md
2. Examples in std.net.tls incorrectly call TcpClient.new as the first parameter is now an array of ips
3. The variable name in one of the examples is inconsistent. The variable is declared as "sock" and then used as "socket"