### PR TITLE
Pass object files to linker using a response file.

### DIFF
--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -651,7 +651,7 @@ LLVM module timings:
 
         let start = Instant::now();
 
-        link(&self.state, &exe, &res.objects)
+        link(&self.state, &exe, &res.objects, directories)
             .map_err(CompileError::Internal)?;
         self.timings.link = start.elapsed();
 

--- a/compiler/src/linker.rs
+++ b/compiler/src/linker.rs
@@ -1,7 +1,8 @@
-use crate::config::{local_runtimes_directory, Linker};
+use crate::config::{local_runtimes_directory, BuildDirectories, Linker};
 use crate::state::State;
 use crate::target::{OperatingSystem, Target, MAC_SDK_VERSION};
-use std::io::Read as _;
+use std::fs::File;
+use std::io::{Read as _, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -187,6 +188,7 @@ pub(crate) fn link(
     state: &State,
     output: &Path,
     paths: &[PathBuf],
+    directories: &BuildDirectories,
 ) -> Result<(), String> {
     let mut cmd = driver(state)?;
 
@@ -194,12 +196,26 @@ pub(crate) fn link(
         cmd.arg(arg);
     }
 
-    // Object files must come before any of the libraries to link against, as
-    // certain linkers are very particular about the order of flags such as
-    // `-l`.
-    for path in paths {
-        cmd.arg(path);
-    }
+    // Create a response file for the linker to allow linking large numbers of object files.
+    // For more details, refer to https://github.com/inko-lang/inko/issues/595.
+    let rsp = directories.objects.join("link.rsp");
+    File::create(&rsp)
+        .and_then(|mut file| {
+            let content = paths
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            file.write_all(content.as_bytes())?;
+
+            cmd.arg(format!("@{}", rsp.display()));
+
+            Ok(())
+        })
+        .map_err(|e| {
+            format!("failed to write objects to {}: {}", rsp.display(), e)
+        })?;
 
     if state.config.target.is_native() {
         cmd.arg(state.config.runtime.join("libinko.a"));


### PR DESCRIPTION
Fixes #595.

Intead of passing object files as arguments to the linker, pass them to the linker
using a response file `build/objects/link.rsp`. This allows linking large numbers of
object files and avoids reaching limits such as argument length.
