### PR TITLE
Pass object files to linker using a response file.

### DIFF
--- a/compiler/src/compiler.rs
+++ b/compiler/src/compiler.rs
@@ -651,7 +651,7 @@ LLVM module timings:
 
         let start = Instant::now();
 
-        link(&self.state, &exe, &res.objects)
+        link(&self.state, &exe, &res.objects, directories)
             .map_err(CompileError::Internal)?;
         self.timings.link = start.elapsed();
 


### PR DESCRIPTION
Fixes #852.

Intead of passing object files as arguments to the linker, pass them to the linker
using a response file `build/objects/link.rsp`. This allows linking large numbers of
object files and avoids reaching limits such as argument length.
