### PR TITLE
Add support for HTTP 1.1 clients and servers

### DIFF
--- a/std/src/std/net/http.inko
+++ b/std/src/std/net/http.inko
@@ -1,0 +1,1523 @@
+# HTTP 1.1 clients and servers.
+#
+# Support for HTTP 1.1 is implemented conforming to the following RFCs:
+#
+# - [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110)
+# - [RFC 9112](https://www.rfc-editor.org/rfc/rfc9112).
+# - [RFC 6265](https://www.rfc-editor.org/rfc/rfc6265).
+import std.bytes (Bytes)
+import std.bytes.parsers (
+  LOWER_A, UPPER_A, ZERO, digit?, digits, lower?, lower_hex_char?, to_lower,
+  upper?, upper_hex_char?,
+)
+import std.clone (Clone)
+import std.cmp (Equal, min)
+import std.fmt (Format, Formatter)
+import std.int (Format as IntFormat, MAX, ToInt)
+import std.io (BufferedRead, BufferedReader, Error as IoError, Read)
+import std.iter (Stream)
+import std.net.http.header
+import std.net.http.method
+import std.string (ToString)
+import std.uri (Uri)
+
+let TAB = 9
+let LF = 10
+let CR = 13
+let SPC = 32
+let EXL = 33
+let HSH = 35
+let DLR = 36
+let PRC = 37
+let AMP = 38
+let SQU = 39
+let AST = 42
+let ADD = 43
+let COM = 44
+let SUB = 45
+let DOT = 46
+let COL = 58
+let SCOL = 59
+let CAR = 94
+let UND = 95
+let GRV = 96
+let PIP = 124
+let TLD = 126
+
+fn inline token?(byte: Int) -> Bool {
+  match byte {
+    case v if lower?(v) or upper?(v) or digit?(v) -> true
+    case
+      EXL
+        or HSH
+        or DLR
+        or PRC
+        or AMP
+        or SQU
+        or AST
+        or ADD
+        or SUB
+        or DOT
+        or CAR
+        or UND
+        or GRV
+        or PIP
+        or TLD
+    -> {
+      true
+    }
+    case _ -> false
+  }
+}
+
+fn inline visible?(byte: Int) -> Bool {
+  byte >= 33 and byte <= 126
+}
+
+# An HTTP header.
+#
+# Standard headers such as `Accept` and `ContentLength` use a dedicated
+# constructor, while non-standard headers use the `Other` constructor.
+type pub inline enum Header {
+  case Accept
+  case AcceptCharset
+  case AcceptEncoding
+  case AcceptLanguage
+  case AcceptRanges
+  case AccessControlAllowCredentials
+  case AccessControlAllowHeaders
+  case AccessControlAllowMethods
+  case AccessControlAllowOrigin
+  case AccessControlMaxAge
+  case AccessControlMethod
+  case AccessControlRequestMethod
+  case AccessControlRequestMethods
+  case AccessControlRequestHeaders
+  case Age
+  case Allow
+  case AltSvc
+  case Authorization
+  case CacheControl
+  case Connection
+  case ContentDisposition
+  case ContentEncoding
+  case ContentLanguage
+  case ContentLength
+  case ContentLocation
+  case ContentRange
+  case ContentType
+  case Cookie
+  case Date
+  case Etag
+  case Expect
+  case Expires
+  case From
+  case Host
+  case IfMatch
+  case IfModifiedSince
+  case IfNoneMatch
+  case IfRange
+  case IfUnmodifiedSince
+  case KeepAlive
+  case LastModified
+  case Link
+  case Location
+  case MaxForwards
+  case Origin
+  case Pragma
+  case ProxyAuthenticate
+  case ProxyAuthorization
+  case ProxyConnection
+  case Range
+  case Referer
+  case RetryAfter
+  case Server
+  case SetCookie
+  case StrictTransportSecurity
+  case Trailer
+  case TransferEncoding
+  case Upgrade
+  case UpgradeInsecureRequests
+  case UserAgent
+  case Vary
+  case Via
+  case WwwAuthenticate
+  case Other(String)
+
+  # Creates a `Header` from a sequence of bytes.
+  #
+  # This method expects that the input is already in lowercase. If this isn't
+  # the case, the input is treated as a non-standard header.
+  #
+  # For non-standard headers the input is converted to a `String` and returned
+  # as `Header.Other`.
+  #
+  # # Examples
+  #
+  # ```inko
+  # import std.net.http (Header)
+  #
+  # Header.parse('content-length') # => Header.ContentLength
+  # Header.parse('example-header') # => Header.Other('example-header')
+  # ```
+  fn pub static parse[B: Bytes + ToString](input: ref B) -> Header {
+    match header.index_of(input) {
+      case 0 -> Accept
+      case 1 -> AcceptCharset
+      case 2 -> AcceptEncoding
+      case 3 -> AcceptLanguage
+      case 4 -> AcceptRanges
+      case 5 -> AccessControlAllowCredentials
+      case 6 -> AccessControlAllowHeaders
+      case 7 -> AccessControlAllowMethods
+      case 8 -> AccessControlAllowOrigin
+      case 9 -> AccessControlMaxAge
+      case 10 -> AccessControlMethod
+      case 11 -> AccessControlRequestMethod
+      case 12 -> AccessControlRequestMethods
+      case 13 -> AccessControlRequestHeaders
+      case 14 -> Age
+      case 15 -> Allow
+      case 16 -> AltSvc
+      case 17 -> Authorization
+      case 18 -> CacheControl
+      case 19 -> Connection
+      case 20 -> ContentDisposition
+      case 21 -> ContentEncoding
+      case 22 -> ContentLanguage
+      case 23 -> ContentLength
+      case 24 -> ContentLocation
+      case 25 -> ContentRange
+      case 26 -> ContentType
+      case 27 -> Cookie
+      case 28 -> Date
+      case 29 -> Etag
+      case 30 -> Expect
+      case 31 -> Expires
+      case 32 -> From
+      case 33 -> Host
+      case 34 -> IfMatch
+      case 35 -> IfModifiedSince
+      case 36 -> IfNoneMatch
+      case 37 -> IfRange
+      case 38 -> IfUnmodifiedSince
+      case 39 -> KeepAlive
+      case 40 -> LastModified
+      case 41 -> Link
+      case 42 -> Location
+      case 43 -> MaxForwards
+      case 44 -> Origin
+      case 45 -> Pragma
+      case 46 -> ProxyAuthenticate
+      case 47 -> ProxyAuthorization
+      case 48 -> ProxyConnection
+      case 49 -> Range
+      case 50 -> Referer
+      case 51 -> RetryAfter
+      case 52 -> Server
+      case 53 -> SetCookie
+      case 54 -> StrictTransportSecurity
+      case 55 -> Trailer
+      case 56 -> TransferEncoding
+      case 57 -> Upgrade
+      case 58 -> UpgradeInsecureRequests
+      case 59 -> UserAgent
+      case 60 -> Vary
+      case 61 -> Via
+      case 62 -> WwwAuthenticate
+      case _ -> Header.Other(input.to_string)
+    }
+  }
+
+  fn index -> Int {
+    match self {
+      case Accept -> 0
+      case AcceptCharset -> 1
+      case AcceptEncoding -> 2
+      case AcceptLanguage -> 3
+      case AcceptRanges -> 4
+      case AccessControlAllowCredentials -> 5
+      case AccessControlAllowHeaders -> 6
+      case AccessControlAllowMethods -> 7
+      case AccessControlAllowOrigin -> 8
+      case AccessControlMaxAge -> 9
+      case AccessControlMethod -> 10
+      case AccessControlRequestMethod -> 11
+      case AccessControlRequestMethods -> 12
+      case AccessControlRequestHeaders -> 13
+      case Age -> 14
+      case Allow -> 15
+      case AltSvc -> 16
+      case Authorization -> 17
+      case CacheControl -> 18
+      case Connection -> 19
+      case ContentDisposition -> 20
+      case ContentEncoding -> 21
+      case ContentLanguage -> 22
+      case ContentLength -> 23
+      case ContentLocation -> 24
+      case ContentRange -> 25
+      case ContentType -> 26
+      case Cookie -> 27
+      case Date -> 28
+      case Etag -> 29
+      case Expect -> 30
+      case Expires -> 31
+      case From -> 32
+      case Host -> 33
+      case IfMatch -> 34
+      case IfModifiedSince -> 35
+      case IfNoneMatch -> 36
+      case IfRange -> 37
+      case IfUnmodifiedSince -> 38
+      case KeepAlive -> 39
+      case LastModified -> 40
+      case Link -> 41
+      case Location -> 42
+      case MaxForwards -> 43
+      case Origin -> 44
+      case Pragma -> 45
+      case ProxyAuthenticate -> 46
+      case ProxyAuthorization -> 47
+      case ProxyConnection -> 48
+      case Range -> 49
+      case Referer -> 50
+      case RetryAfter -> 51
+      case Server -> 52
+      case SetCookie -> 53
+      case StrictTransportSecurity -> 54
+      case Trailer -> 55
+      case TransferEncoding -> 56
+      case Upgrade -> 57
+      case UpgradeInsecureRequests -> 58
+      case UserAgent -> 59
+      case Vary -> 60
+      case Via -> 61
+      case WwwAuthenticate -> 62
+      case Other(_) -> 63
+    }
+  }
+}
+
+impl Equal for Header {
+  fn pub ==(other: ref Header) -> Bool {
+    match (self, other) {
+      case (Other(a), Other(b)) -> a == b
+      case (a, b) -> a.index == b.index
+    }
+  }
+}
+
+impl ToString for Header {
+  fn pub to_string -> String {
+    match self {
+      case Other(v) -> v
+      case _ -> header.NAMES.get(index).or_panic
+    }
+  }
+}
+
+impl Format for Header {
+  fn pub fmt(formatter: mut Formatter) {
+    match self {
+      case Other(v) -> formatter.write(v)
+      case _ -> formatter.write(header.NAMES.get(index).or_panic)
+    }
+  }
+}
+
+type copy Bitmap {
+  let @value: Int
+
+  fn inline static new -> Self {
+    Self(0)
+  }
+
+  fn inline with(bit: Int) -> Self {
+    Self(@value | (1 << bit))
+  }
+
+  fn inline contains?(bit: Int) -> Bool {
+    @value & (1 << bit) != 0
+  }
+}
+
+impl Format for Bitmap {
+  fn pub fmt(formatter: mut Formatter) {
+    formatter
+      .object('Bitmap')
+      .field('value', @value.format(IntFormat.Binary))
+      .finish
+  }
+}
+
+# An error that signals the lack of a header in a `HeaderMap`.
+type pub inline MissingHeader {
+  # The header that is missing.
+  let pub @header: ref Header
+}
+
+impl ToString for MissingHeader {
+  fn pub to_string -> String {
+    let name = match @header {
+      case Other(name) -> name
+      case _ -> header.NAMES.get(@header.index).or_panic
+    }
+
+    "the header '${name}' is missing"
+  }
+}
+
+impl Format for MissingHeader {
+  fn pub fmt(formatter: mut Formatter) {
+    formatter.object('MissingHeader').field('header', @header).finish
+  }
+}
+
+impl Equal for MissingHeader {
+  fn pub ==(other: ref MissingHeader) -> Bool {
+    @header == other.header
+  }
+}
+
+# A mapping of HTTP headers and their values.
+#
+# A `HeaderMap` is a specialized `Map`-like type that takes advantage of how
+# `Header` values are represented, allowing for more efficient lookups compared
+# to the use of a regular `Map`.
+#
+# Insertions and lookups don't perform any case conversion when using
+# non-standard headers. This means that non-standard headers must be converted
+# to their lowercase form first.
+type pub HeaderMap {
+  # A bitmap used to record if a header is present in the first place.
+  #
+  # For standard headers this allows bypassing lookups entirely if we know for a
+  # fact a header isn't present, essentially turning the lookup into a no-op.
+  #
+  # For non-standard headers this is only effective if there are no non-standard
+  # headers at all, i.e. the "Other" bit simply signals _a_ non-standard header
+  # is present, not which ones.
+  let mut @bitmap: Bitmap
+
+  # An `Array` of values for standard headers.
+  #
+  # The size of this `Array` is equal to the number of standard headers.
+  let @standard: Array[HeaderValue]
+
+  # A `Map` of non-standard header names to their values.
+  let @non_standard: Map[String, HeaderValue]
+
+  # Returns a new and empty `HeaderMap`.
+  fn pub static new -> Self {
+    Self(
+      bitmap: Bitmap.new,
+      standard: Array.filled(with: HeaderValue.None, times: header.NAMES.size),
+      non_standard: Map.new,
+    )
+  }
+
+  # Adds a `Header` to `self`.
+  #
+  # If the header is already assigned a value, the existing value is turned into
+  # an `Array` and the new value is appended to this `Array`.
+  #
+  # The returned value is `true` if the header is already assigned a value,
+  # otherwise it's `false`.
+  #
+  # # Examples
+  #
+  # ```inko
+  # import std.net.http (Header, HeaderMap)
+  #
+  # let map = HeaderMap.new
+  #
+  # map.add(Header.ContentLength, '128') # => false
+  # map.add(Header.ContentLength, '256') # => true
+  # map.add(Header.Host, 'example.com') # => false
+  # ```
+  fn pub mut add(header: Header, value: String) -> Bool {
+    let idx = header.index
+
+    @bitmap = @bitmap.with(idx)
+
+    match header {
+      case Other(name) -> {
+        match @non_standard.get_mut(name) {
+          case Ok(Single(ex)) -> {
+            @non_standard.set(name, HeaderValue.Multiple([ex, value]))
+            true
+          }
+          case Ok(Multiple(ex)) -> {
+            ex.push(value)
+            true
+          }
+          case _ -> {
+            @non_standard.set(name, HeaderValue.Single(value))
+            false
+          }
+        }
+      }
+      case _ -> {
+        match @standard.get_mut(idx).or_panic {
+          case None -> {
+            @standard.set(idx, HeaderValue.Single(value))
+            false
+          }
+          case Single(ex) -> {
+            @standard.set(idx, HeaderValue.Multiple([ex, value]))
+            true
+          }
+          case Multiple(ex) -> {
+            ex.push(value)
+            true
+          }
+        }
+      }
+    }
+  }
+
+  # Returns the first value of the given `Header`, if there is any.
+  #
+  # If the header isn't present, a `MissingHeader` error is returned.
+  #
+  # # Examples
+  #
+  # ```inko
+  # import std.net.http (Header, HeaderMap)
+  #
+  # let map = HeaderMap.new
+  #
+  # map.add(Header.ContentLength, '128')
+  # map.get(Header.ContentLength) # => Result.Ok('128')
+  # ```
+  fn pub get(header: ref Header) -> Result[String, MissingHeader] {
+    match get_value(header) {
+      case Ok(Single(v)) -> Result.Ok(v)
+      case Ok(Multiple(v)) -> Result.Ok(v.get(0).or_panic)
+      case _ -> Result.Error(MissingHeader(header))
+    }
+  }
+
+  fn get_value(header: ref Header) -> Result[ref HeaderValue, MissingHeader] {
+    let idx = header.index
+
+    # If the header definitely isn't present we can skip the lookup entirely.
+    if @bitmap.contains?(idx).false? { throw MissingHeader(header) }
+
+    match header {
+      case Other(name) -> {
+        match @non_standard.get(name) {
+          case Ok(v) -> Result.Ok(v)
+          case _ -> Result.Error(MissingHeader(header))
+        }
+      }
+      case _ -> {
+        match @standard.get(idx) {
+          case Ok(v) -> Result.Ok(v)
+          case _ -> Result.Error(MissingHeader(header))
+        }
+      }
+    }
+  }
+
+  # Returns an iterator over all the values of the header.
+  #
+  # If the header isn't assigned any values, the returned iterator yields no
+  # values.
+  #
+  # If the header value is a comma-separated list, this method treats it as a
+  # single value.
+  #
+  # # Examples
+  #
+  # ```inko
+  # import std.net.http (Header, HeaderMap)
+  #
+  # let map = HeaderMap.new
+  #
+  # map.add(Header.ContentLength, '10')
+  # map.add(Header.ContentLength, '20')
+  #
+  # let iter = map.get_all(Header.ContentLength)
+  #
+  # iter.next # => Option.Some('10')
+  # iter.next # => Option.Some('20')
+  # iter.next # => Option.None
+  # ```
+  fn pub get_all(header: ref Header) -> Stream[String] {
+    let idx = header.index
+    let val = if @bitmap.contains?(idx) {
+      match header {
+        case Other(name) -> {
+          match @non_standard.get(name) {
+            case Ok(v) -> Option.Some(v)
+            case _ -> Option.None
+          }
+        }
+        case _ -> {
+          match @standard.get(idx) {
+            case Ok(v) -> Option.Some(v)
+            case _ -> Option.None
+          }
+        }
+      }
+    } else {
+      Option.None
+    }
+
+    match val {
+      case Some(Single(v)) -> {
+        let mut done = false
+
+        Stream.new(fn move {
+          if done := true { Option.None } else { Option.Some(v) }
+        })
+      }
+      case Some(Multiple(v)) -> v.iter
+      case _ -> Stream.new(fn move { Option.None })
+    }
+  }
+
+  # Parses and returns the value of the `Content-Length` header.
+  #
+  # # Handling duplicate headers
+  #
+  # RFC 9110 specifies the value format as `1*DIGIT` and not a list, but also
+  # says that _if_ the value is a comma-separated list where each value is the
+  # same (e.g. `Content-Length: 10, 20`) it's up to the receiver to determine
+  # how to handle such headers.
+  #
+  # Because multiple `Content-Length` headers are most likely the result of a
+  # bug and may result in security vulnerabilities (e.g. due to request
+  # smuggling), we always reject such headers. In other words, the only form we
+  # support is a single occurrence of the header in the form
+  # `Content-Length: digits`.
+  fn content_length -> Result[Option[Int], ParseError] {
+    match get_value(Header.ContentLength) {
+      case Ok(Single(inp)) -> {
+        match digits(inp, start: 0, limit: 19) {
+          case Some((v, len)) if len == inp.size -> Result.Ok(Option.Some(v))
+          case _ -> {
+            Result.Error(ParseError.InvalidHeaderValue(Header.ContentLength))
+          }
+        }
+      }
+      case Ok(Multiple(_)) -> {
+        Result.Error(ParseError.InvalidHeaderValue(Header.ContentLength))
+      }
+      case _ -> Result.Ok(Option.None)
+    }
+  }
+}
+
+impl Format for HeaderMap {
+  fn pub fmt(formatter: mut Formatter) {
+    let mut len = 0
+
+    formatter.write('{')
+
+    for (idx, val) in @standard.iter.with_index {
+      match val {
+        case None -> next
+        case _ -> {}
+      }
+
+      if len > 0 { formatter.write(', ') }
+
+      let name = header.NAMES.get(idx).or_panic
+
+      formatter.write(name)
+      formatter.write(': ')
+
+      match val {
+        case Single(v) -> v.fmt(formatter)
+        case Multiple(v) -> v.fmt(formatter)
+        case _ -> {}
+      }
+
+      len += 1
+    }
+
+    for { @key = name, @value = val } in @non_standard.iter {
+      if len > 0 { formatter.write(', ') }
+
+      formatter.write(name)
+      formatter.write(': ')
+
+      match val {
+        case Single(v) -> v.fmt(formatter)
+        case Multiple(v) -> v.fmt(formatter)
+        case _ -> {}
+      }
+
+      len += 1
+    }
+
+    formatter.write('}')
+  }
+}
+
+# The value of a header.
+type inline enum HeaderValue {
+  # The header is not assigned any value.
+  case None
+
+  # The header is assigned only a single value.
+  #
+  # This is a dedicated constructor as most headers only ever have a single
+  # value, allowing us to avoid the need for allocating an Array.
+  case Single(String)
+
+  # The header is assigned multiple values.
+  case Multiple(Array[String])
+}
+
+impl Format for HeaderValue {
+  fn pub fmt(formatter: mut Formatter) {
+    match self {
+      case None -> formatter.tuple('None').finish
+      case Single(v) -> formatter.tuple('Single').field(v).finish
+      case Multiple(v) -> formatter.tuple('Multiple').field(v).finish
+    }
+  }
+}
+
+impl Clone for HeaderValue {
+  fn pub clone -> Self {
+    match self {
+      case None -> HeaderValue.None
+      case Single(v) -> HeaderValue.Single(v)
+      case Multiple(v) -> HeaderValue.Multiple(v.clone)
+    }
+  }
+}
+
+# An HTTP request method.
+#
+# Only the standard request methods defined in RFC 9112 are supported. Custom
+# request methods aren't supported as they're virtually unused, and frankly not
+# that useful.
+type pub copy enum Method {
+  case Get
+  case Post
+  case Put
+  case Delete
+  case Head
+  case Options
+  case Connect
+  case Trace
+
+  # Creates a `Method` from a sequence of bytes.
+  #
+  # If the request method isn't recognized, an `Option.None` is returned.
+  #
+  # # Examples
+  #
+  # ```inko
+  # import std.net.http (Method)
+  #
+  # Method.parse('GET') # => Option.Some(Method.Get)
+  # Method.parse('FOO') # => Option.None
+  # ```
+  fn pub static parse[B: Bytes](input: ref B) -> Option[Method] {
+    match method.index_of(input) {
+      case Some(0) -> Option.Some(Get)
+      case Some(1) -> Option.Some(Post)
+      case Some(2) -> Option.Some(Put)
+      case Some(3) -> Option.Some(Delete)
+      case Some(4) -> Option.Some(Head)
+      case Some(5) -> Option.Some(Options)
+      case Some(6) -> Option.Some(Connect)
+      case Some(7) -> Option.Some(Trace)
+      case _ -> Option.None
+    }
+  }
+}
+
+impl Equal for Method {
+  fn pub ==(other: Method) -> Bool {
+    match (self, other) {
+      case (Get, Get) -> true
+      case (Post, Post) -> true
+      case (Put, Put) -> true
+      case (Delete, Delete) -> true
+      case (Head, Head) -> true
+      case (Options, Options) -> true
+      case (Connect, Connect) -> true
+      case (Trace, Trace) -> true
+      case _ -> false
+    }
+  }
+}
+
+impl ToString for Method {
+  fn pub to_string -> String {
+    match self {
+      case Get -> 'GET'
+      case Post -> 'POST'
+      case Put -> 'PUT'
+      case Delete -> 'DELETE'
+      case Head -> 'HEAD'
+      case Options -> 'OPTIONS'
+      case Connect -> 'CONNECT'
+      case Trace -> 'TRACE'
+    }
+  }
+}
+
+impl Format for Method {
+  fn pub fmt(formatter: mut Formatter) {
+    formatter.write(to_string)
+  }
+}
+
+# The status code of a response.
+type pub copy Status {
+  let @code: Int
+
+  # Returns a new `Status` using the given status code.
+  fn inline static new(code: Int) -> Status {
+    Status(code)
+  }
+
+  # Returns the `OK` status code.
+  fn inline static ok -> Status {
+    Status(200)
+  }
+}
+
+impl Equal for Status {
+  fn pub ==(other: Status) -> Bool {
+    @code == other.code
+  }
+}
+
+impl ToString for Status {
+  fn pub to_string -> String {
+    @code.to_string
+  }
+}
+
+impl Format for Status {
+  fn pub fmt(formatter: mut Formatter) {
+    @code.fmt(formatter)
+  }
+}
+
+impl ToInt for Status {
+  fn pub to_int -> Int {
+    @code
+  }
+}
+
+# The version of the HTTP protocol used by a request or response.
+type pub copy Version {
+  # The major version number.
+  let pub @major: Int
+
+  # The minor version number.
+  let pub @minor: Int
+}
+
+impl Format for Version {
+  fn pub fmt(formatter: mut Formatter) {
+    formatter
+      .object('Version')
+      .field('major', @major)
+      .field('minor', @minor)
+      .finish
+  }
+}
+
+# An HTTP request.
+type pub inline Request[T: mut + Read[IoError]] {
+  # The request method (e.g. GET).
+  let pub @method: Method
+
+  # The URI of the request.
+  let pub @uri: Uri
+
+  # The HTTP protocol version.
+  let pub @version: Version
+
+  # The headers of the request.
+  let pub @headers: HeaderMap
+
+  # The body of the request.
+  let pub @body: Body
+}
+
+impl Format for Request {
+  fn pub fmt(formatter: mut Formatter) {
+    # TODO: formatting the body requires `T: Format`, but this triggers the
+    # compiler error from https://github.com/inko-lang/inko/issues/851#issuecomment-2848531815.
+    formatter
+      .object('Request')
+      .field('method', @method)
+      .field('uri', @uri)
+      .field('version', @version)
+      .field('headers', @headers)
+      .field('body', '[...]')
+      .finish
+  }
+}
+
+# A type that reads a body the regular (i.e. not chunked) way.
+type RegularReader[T: mut + Read[IoError]] {
+  # The number of remaining bytes that can be read from the input stream.
+  let mut @remaining: Int
+
+  # The underlying input stream (e.g. a socket).
+  #
+  # While we don't need buffering ourselves, the parser makes use of buffering
+  # and thus some data may reside in the in-memory buffer instead of the
+  # underlying stream. As such, we just reuse the buffered stream as-is.
+  let @inner: BufferedReader[T, IoError]
+}
+
+impl Read[ParseError] for RegularReader {
+  fn pub mut read(into: mut ByteArray, size: Int) -> Result[Int, ParseError] {
+    match min(size, @remaining) {
+      case 0 -> Result.Ok(0)
+      case n -> {
+        match @inner.read(into, n) {
+          case Ok(v) -> {
+            @remaining -= v
+            Result.Ok(v)
+          }
+          case Error(e) -> throw ParseError.Read(e)
+        }
+      }
+    }
+  }
+}
+
+type copy enum ChunkState {
+  case Start
+  case Pending(Int)
+  case End
+}
+
+# A reader for requests/responses that use chunked transfer coding.
+type ChunkedReader[T: mut + BufferedRead[IoError]] {
+  # The number of remaining bytes that can be read from the input stream.
+  #
+  # This number only applies to the chunk bodies and not e.g. the number of
+  # bytes that need to be read for the chunk sizes.
+  let mut @remaining: Int
+
+  # The underlying input stream (e.g. a socket).
+  let @reader: T
+
+  # The current state we're in.
+  let mut @state: ChunkState
+
+  fn static new(reader: T, size: Int) -> Self {
+    Self(remaining: size, reader: reader, state: ChunkState.Start)
+  }
+
+  fn mut read_chunk_size -> Result[Int, ParseError] {
+    let mut len = 0
+    let mut chunk_ext = false
+    let mut digits = 0
+
+    match @reader.peek {
+      case Ok(Some(_)) -> {}
+      case Ok(_) -> return Result.Ok(0)
+      case Error(e) -> throw ParseError.Read(e)
+    }
+
+    loop {
+      let digit = match try require_byte {
+        case n if digit?(n) -> n - ZERO
+        case n if lower_hex_char?(n) -> n - LOWER_A + 10
+        case n if upper_hex_char?(n) -> n - UPPER_A + 10
+        case SCOL -> {
+          chunk_ext = true
+          break
+        }
+        case CR if (try require_byte) == LF -> break
+        case _ -> throw ParseError.InvalidChunk
+      }
+
+      # Hexadecimal signed integers support up to 16 digits, or 8 EiB of memory.
+      # We _may_ encounter more if somebody uses a size such as
+      # "000000000000000012". We treat such sizes as invalid as otherwise an
+      # attacker could exhaust our resources by supplying _really_ long chunk
+      # sizes.
+      if digits == 16 { throw ParseError.InvalidChunk }
+
+      len = try len.checked_mul(16).ok_or(ParseError.InvalidChunk)
+      len = try len.checked_add(digit).ok_or(ParseError.InvalidChunk)
+      digits += 1
+    }
+
+    # Chunk extensions are hardly ever used and so we ignore them. We still need
+    # to apply the size limit such that an attacker can't exhaust our resources
+    # by using an excessively large chunk extension.
+    while chunk_ext {
+      match try require_byte {
+        case CR -> {
+          match try require_byte {
+            case LF -> break
+            case _ -> throw ParseError.InvalidChunk
+          }
+        }
+        case _ if @remaining == 0 -> throw ParseError.BodyTooLarge
+        case _ -> @remaining -= 1
+      }
+    }
+
+    # We check for this last so we take into account the number of bytes
+    # consumed by the chunk extension.
+    if len > @remaining { throw ParseError.BodyTooLarge }
+
+    Result.Ok(len)
+  }
+
+  fn inline mut require_byte -> Result[Int, ParseError] {
+    match @reader.read_byte {
+      case Ok(Some(n)) -> Result.Ok(n)
+      case Ok(_) -> Result.Error(ParseError.EndOfInput)
+      case Error(e) -> Result.Error(ParseError.Read(e))
+    }
+  }
+}
+
+impl Read[ParseError] for ChunkedReader {
+  fn pub mut read(into: mut ByteArray, size: Int) -> Result[Int, ParseError] {
+    let mut pending = size
+
+    while pending > 0 {
+      let rem = match @state {
+        case Start -> {
+          match try read_chunk_size {
+            case 0 -> {
+              @state = ChunkState.End
+              return Result.Ok(size - pending)
+            }
+            case n -> n
+          }
+        }
+        case Pending(v) -> v
+        case End -> return Result.Ok(0)
+      }
+
+      match @reader.read(into: into, size: min(pending, rem)) {
+        case Ok(0) -> break
+        case Ok(n) -> {
+          let new = rem - n
+
+          @state = if new == 0 {
+            match try require_byte {
+              case CR if (try require_byte) == LF -> ChunkState.Start
+              case _ -> throw ParseError.InvalidChunk
+            }
+          } else {
+            ChunkState.Pending(new)
+          }
+
+          @remaining -= n
+          pending -= n
+        }
+        case Error(e) -> throw ParseError.Read(e)
+      }
+    }
+
+    Result.Ok(size - pending)
+  }
+}
+
+# The body of a response or request to read.
+type pub inline Body {
+  let @reader: Read[ParseError]
+
+  fn static regular[T: mut + Read[IoError]](
+    reader: BufferedReader[T, IoError],
+    size: Int,
+  ) -> Body {
+    Body(RegularReader(remaining: size, inner: reader) as Read[ParseError])
+  }
+
+  fn static chunked[T: mut + Read[IoError]](
+    reader: BufferedReader[T, IoError],
+    size: Int,
+  ) -> Body {
+    Body(ChunkedReader.new(reader, size) as Read[ParseError])
+  }
+}
+
+impl Read[ParseError] for Body {
+  fn pub mut read(into: mut ByteArray, size: Int) -> Result[Int, ParseError] {
+    @reader.read(into, size)
+  }
+}
+
+# A collection of cookies to include in a request or response.
+type pub inline Cookies {
+  let @map: Map[String, String]
+
+  # Returns a new `Cookies` value.
+  fn pub static new -> Self {
+    Self(Map.new)
+  }
+
+  # Assigns a cookie a new value.
+  fn pub mut set(name: String, value: String) {
+    @map.set(name, value)
+  }
+}
+
+impl Format for Cookies {
+  fn pub fmt(formatter: mut Formatter) {
+    formatter.object('Cookies').field('map', @map).finish
+  }
+}
+
+# An HTTP response.
+type pub inline Response[T: mut + Read[IoError]] {
+  # The request method (e.g. GET).
+  let pub @method: Method
+
+  # The HTTP status code.
+  let pub @status: Status
+
+  # The HTTP protocol version.
+  let pub @version: Version
+
+  # The headers of the request.
+  let pub @headers: HeaderMap
+
+  # The body of the request.
+  let pub @body: T
+}
+
+# An error produced while parsing a request or response.
+type pub inline enum ParseError {
+  # The request method is invalid.
+  case InvalidMethod
+
+  # The requested URI is invalid.
+  case InvalidUri(String)
+
+  # The HTTP version is invalid.
+  case InvalidVersion
+
+  # A header name or value contains invalid characters.
+  case InvalidHeaderBytes
+
+  # A header name or value is too large.
+  case HeaderTooLarge
+
+  # A request or response contains too many headers.
+  case TooManyHeaders
+
+  # A header value is invalid (e.g. it's a list of values when only a single
+  # value is supported).
+  case InvalidHeaderValue(Header)
+
+  # Two conflicting headers are given.
+  case ConflictingHeaders(Header, Header)
+
+  # The request or response body is larger than the allowed limit.
+  case BodyTooLarge
+
+  # A chunked transfer coding chunk is invalid.
+  case InvalidChunk
+
+  # More input is required.
+  case EndOfInput
+
+  # An error produced while reading data from the input stream.
+  case Read(IoError)
+}
+
+impl ToString for ParseError {
+  fn pub to_string -> String {
+    match self {
+      case InvalidMethod -> 'the request method is invalid'
+      case InvalidUri(v) -> 'the request URI is invalid: ${v}'
+      case InvalidVersion -> 'the HTTP version is invalid'
+      case InvalidHeaderBytes -> 'a header name or value contains invalid bytes'
+      case HeaderTooLarge -> 'a header name or value is too large'
+      case TooManyHeaders -> 'too many headers are specified'
+      case InvalidHeaderValue(v) -> 'the value of the ${v} header is invalid'
+      case BodyTooLarge -> 'the request or response body is too large'
+      case ConflictingHeaders(a, b) -> {
+        "the ${a} and ${b} headers can't be specified at the same time"
+      }
+      case InvalidChunk -> 'a chunked transfer coding chunk is invalid'
+      case EndOfInput -> {
+        'the end of the input stream is reached, but more input is required'
+      }
+      case Read(v) -> v.to_string
+    }
+  }
+}
+
+impl Format for ParseError {
+  fn pub fmt(formatter: mut Formatter) {
+    match self {
+      case InvalidMethod -> formatter.tuple('InvalidMethod').finish
+      case InvalidUri(v) -> formatter.tuple('InvalidUri').field(v).finish
+      case InvalidVersion -> formatter.tuple('InvalidVersion').finish
+      case InvalidHeaderBytes -> formatter.tuple('InvalidHeaderBytes').finish
+      case HeaderTooLarge -> formatter.tuple('HeaderTooLarge').finish
+      case TooManyHeaders -> formatter.tuple('TooManyHeaders').finish
+      case InvalidHeaderValue(v) -> {
+        formatter.tuple('InvalidHeaderValue').field(v).finish
+      }
+      case ConflictingHeaders(a, b) -> {
+        formatter.tuple('ConflictingHeaders').field(a).field(b).finish
+      }
+      case BodyTooLarge -> formatter.tuple('BodyTooLarge').finish
+      case InvalidChunk -> formatter.tuple('InvalidChunkSize').finish
+      case EndOfInput -> formatter.tuple('EndOfInput').finish
+      case Read(v) -> formatter.tuple('Read').field(v).finish
+    }
+  }
+}
+
+impl Equal for ParseError {
+  fn pub ==(other: ref ParseError) -> Bool {
+    match (self, other) {
+      case (InvalidMethod, InvalidMethod) -> true
+      case (InvalidUri(a), InvalidUri(b)) -> a == b
+      case (InvalidVersion, InvalidVersion) -> true
+      case (InvalidHeaderBytes, InvalidHeaderBytes) -> true
+      case (HeaderTooLarge, HeaderTooLarge) -> true
+      case (TooManyHeaders, TooManyHeaders) -> true
+      case (InvalidHeaderValue(a), InvalidHeaderValue(b)) -> a == b
+      case (ConflictingHeaders(a1, b1), ConflictingHeaders(a2, b2)) -> {
+        a1 == a2 and b1 == b2
+      }
+      case (BodyTooLarge, BodyTooLarge) -> true
+      case (InvalidChunk, InvalidChunk) -> true
+      case (EndOfInput, EndOfInput) -> true
+      case (Read(a), Read(b)) -> a == b
+      case _ -> false
+    }
+  }
+}
+
+# Settings to alter the behavior of parsing requests and responses.
+type pub Config {
+  # The maximum size of request targets (e.g. URIs).
+  #
+  # This defaults to 1 KiB.
+  let pub mut @target_size: Int
+
+  # The maximum size (in bytes) of header names and values.
+  #
+  # This defaults to 4 KiB as most (all?) browsers also enforce this upper limit
+  # on the size of cookies, which is typically the largest header value.
+  let pub mut @header_size: Int
+
+  # The maximum number of headers that are allowed.
+  #
+  # This defaults to 32.
+  let pub mut @headers: Int
+
+  # The maximum size (in bytes) of a request body.
+  #
+  # This defaults to 1 MiB.
+  #
+  # This limits ensures servers don't run out of memory due to requests
+  # including unreasonably large bodies. You may need to increase this limit if
+  # you want to allow handling of large file uploads.
+  #
+  # If chunked transfer coding is used, the limit is applied to the total size
+  # of all chunk bodies and their chunk extensions. The limit is applied by
+  # looking at the size of each chunk, regardless of the desired number of bytes
+  # to read.
+  let pub mut @request_body_size: Int
+
+  # The maximum size (in bytes) of a response body.
+  #
+  # This defaults to the maximum `Int` value (= i.e. 7 ZiB), meaning it's
+  # effectively unlimited by default. The reason for this is that most servers
+  # won't respond with large responses unless that's intentional/desired (e.g.
+  # when downloading a file).
+  #
+  # If chunked transfer coding is used, the limit is applied to the total size
+  # of all chunk bodies and their chunk extensions. The limit is applied by
+  # looking at the size of each chunk, regardless of the desired number of bytes
+  # to read.
+  let pub mut @response_body_size: Int
+
+  # Returns a `Config` using the default settings.
+  fn pub static new -> Self {
+    Self(
+      target_size: 1024,
+      header_size: 4 * 1024,
+      headers: 32,
+      request_body_size: 1024 * 1024,
+      response_body_size: MAX,
+    )
+  }
+}
+
+impl Clone for Config {
+  fn pub clone -> Config {
+    Config(
+      target_size: @target_size,
+      header_size: @header_size,
+      headers: @headers,
+      request_body_size: @request_body_size,
+      response_body_size: @response_body_size,
+    )
+  }
+}
+
+# A type for parsing an HTTP requests and responses.
+type pub inline Parser[T: mut + Read[IoError]] {
+  let @reader: BufferedReader[T, IoError]
+  let @buffer: ByteArray
+  let @config: Config
+
+  # Returns a new `Parser`.
+  fn pub static new(reader: T, config: Config) -> Self {
+    Self(
+      reader: BufferedReader.new(reader),
+      buffer: ByteArray.new,
+      config: config,
+    )
+  }
+
+  # Parses the input stream into a `Request`.
+  fn pub move request -> Result[Request[T], ParseError] {
+    let method = try request_method
+    let uri = try uri
+    let version = try version
+
+    if (try terminated?) == false { throw ParseError.EndOfInput }
+
+    let headers = try headers
+
+    # Due to https://github.com/inko-lang/inko/issues/864 we have to move this
+    # field ahead of time.
+    #
+    # We cast this value to a trait such that we don't leak parser internals
+    # (e.g. the use of a `BufferedReader` while parsing).
+    let reader = @reader
+    let body = match method {
+      # CONNECT and HEAD requests don't use a body (RFC 9112 section 6.3).
+      case Connect or Head -> Body.regular(reader, size: 0)
+      case _ -> {
+        let cl = Header.ContentLength
+        let te = Header.TransferEncoding
+
+        match (headers.content_length, headers.get_value(te)) {
+          # Specifying both Content-Length and Transfer-Encoding is either a bug
+          # or an attempt at request smuggling (or a similar attack). Per RFC
+          # 9112 ("[...] and ought to be handled as an error" in section 6.3) we
+          # reject such messages.
+          case (Ok(Some(_)), Ok(_)) -> {
+            throw ParseError.ConflictingHeaders(cl, te)
+          }
+          case (Ok(Some(len)), _) if len > @config.request_body_size -> {
+            throw ParseError.BodyTooLarge
+          }
+          case (Ok(Some(len)), _) -> Body.regular(reader, len)
+          # We only support the "chunked" encoding, as the others aren't all
+          # that useful, and because at the time of writing we don't support
+          # gzip/deflate/etc in the standard library.
+          case (_, Ok(Single('chunked'))) -> {
+            Body.chunked(reader, @config.request_body_size)
+          }
+          case (_, Ok(_)) -> throw ParseError.InvalidHeaderValue(te)
+          case (Error(e), _) -> throw e
+          case _ -> Body.regular(reader, size: 0)
+        }
+      }
+    }
+
+    Result.Ok(
+      Request(
+        method: method,
+        uri: uri,
+        version: version,
+        headers: headers,
+        body: body,
+      ),
+    )
+  }
+
+  fn mut request_method -> Result[Method, ParseError] {
+    loop {
+      match @reader.read_byte {
+        case Ok(Some(SPC)) -> break
+        case Ok(Some(_)) if @buffer.size == method.MAX_SIZE -> {
+          throw ParseError.InvalidMethod
+        }
+        case Ok(Some(v)) -> @buffer.push(v)
+        case Ok(_) -> throw ParseError.EndOfInput
+        case Error(e) -> throw ParseError.Read(e)
+      }
+    }
+
+    let res = match Method.parse(@buffer) {
+      case Some(v) -> Result.Ok(v)
+      case _ -> Result.Error(ParseError.InvalidMethod)
+    }
+
+    @buffer.clear
+    res
+  }
+
+  fn mut uri -> Result[Uri, ParseError] {
+    loop {
+      match @reader.read_byte {
+        case Ok(Some(SPC)) -> break
+        case Ok(Some(_)) if @buffer.size > @config.target_size -> {
+          throw ParseError.InvalidUri('the size is too large')
+        }
+        case Ok(Some(v)) -> @buffer.push(v)
+        case Ok(_) -> throw ParseError.EndOfInput
+        case Error(e) -> throw ParseError.Read(e)
+      }
+    }
+
+    let res = match Uri.parse(@buffer) {
+      case Ok(v) -> Result.Ok(v)
+      case Error(e) -> Result.Error(ParseError.InvalidUri(e.to_string))
+    }
+
+    @buffer.clear
+    res
+  }
+
+  fn mut version -> Result[Version, ParseError] {
+    # The only HTTP versions supported/in use all take up exactly 8 bytes:
+    # HTTP/0.9, HTTP/1.0, HTTP/1.1, and HTTP/2.0.
+    match @reader.read_exact(into: @buffer, size: 8) {
+      case Ok(_) if @buffer.starts_with?('HTTP/') -> {}
+      case Ok(_) -> throw ParseError.InvalidVersion
+      case Error(EndOfInput) -> throw ParseError.EndOfInput
+      case Error(Read(e)) -> throw ParseError.Read(e)
+    }
+
+    let a = @buffer.get(5).or_panic
+    let b = @buffer.get(7).or_panic
+    let res = if digit?(a) and @buffer.get(6).or_panic == DOT and digit?(b) {
+      Result.Ok(Version(major: a - ZERO, minor: b - ZERO))
+    } else {
+      Result.Error(ParseError.InvalidVersion)
+    }
+
+    @buffer.clear
+    res
+  }
+
+  fn mut terminated? -> Result[Bool, ParseError] {
+    let res = match @reader.read_exact(into: @buffer, size: 2) {
+      case Ok(_) if @buffer.equals?('\r\n') -> Result.Ok(true)
+      case Ok(_) -> Result.Ok(false)
+      case Error(EndOfInput) -> throw ParseError.EndOfInput
+      case Error(Read(e)) -> Result.Error(ParseError.Read(e))
+    }
+
+    @buffer.clear
+    res
+  }
+
+  fn mut headers -> Result[HeaderMap, ParseError] {
+    let mut num = 0
+    let headers = HeaderMap.new
+
+    # TODO: a bunch of headers allow duplicate (Set-Cookie, Cache-Control, etc).
+    # How do we handle that?
+    # TODO: only allow duplicates for headers of which the values are lists,
+    # produce error for everything else
+    loop {
+      match header {
+        case Ok(Some(_)) if num == @config.headers -> {
+          throw ParseError.TooManyHeaders
+        }
+        case Ok(Some((name, val))) -> {
+          headers.add(name, val)
+          num += 1
+        }
+        case Ok(_) -> break
+        case Error(e) -> throw e
+      }
+    }
+
+    Result.Ok(headers)
+  }
+
+  fn mut header -> Result[Option[(Header, String)], ParseError] {
+    loop {
+      match @reader.read_byte {
+        case Ok(Some(COL)) -> break
+        case Ok(Some(CR)) -> {
+          match @reader.read_byte {
+            case Ok(Some(LF)) -> return Result.Ok(Option.None)
+            case Ok(Some(_)) -> throw ParseError.InvalidHeaderBytes
+            case Ok(_) -> throw ParseError.EndOfInput
+            case Error(e) -> throw ParseError.Read(e)
+          }
+        }
+        case Ok(Some(_)) if @buffer.size == @config.header_size -> {
+          throw ParseError.HeaderTooLarge
+        }
+        case Ok(Some(v)) if upper?(v) -> @buffer.push(to_lower(v))
+        case Ok(Some(v)) if token?(v) -> @buffer.push(v)
+        case Ok(Some(_)) -> throw ParseError.InvalidHeaderBytes
+        case Ok(_) -> return Result.Ok(Option.None)
+        case Error(e) -> throw ParseError.Read(e)
+      }
+    }
+
+    let name = Header.parse(@buffer)
+
+    @buffer.clear
+    try skip_spaces
+
+    loop {
+      match @reader.read_byte {
+        case Ok(Some(v)) if visible?(v) or v == SPC or v == TAB -> {
+          @buffer.push(v)
+        }
+        case Ok(Some(CR)) -> {
+          match @reader.read_byte {
+            case Ok(Some(LF)) -> break
+            case Ok(Some(_)) -> throw ParseError.InvalidHeaderBytes
+            case Ok(_) -> throw ParseError.EndOfInput
+            case Error(e) -> throw ParseError.Read(e)
+          }
+        }
+        case Ok(Some(_)) if @buffer.size == @config.header_size -> {
+          throw ParseError.HeaderTooLarge
+        }
+        case Ok(Some(_)) -> throw ParseError.InvalidHeaderBytes
+        case Ok(_) -> throw ParseError.EndOfInput
+        case Error(e) -> throw ParseError.Read(e)
+      }
+    }
+
+    # If there's any trailing whitespace, it needs to be removed.
+    loop {
+      match @buffer.last {
+        case Some(SPC or TAB) -> @buffer.pop
+        case _ -> break
+      }
+    }
+
+    Result.Ok(Option.Some((name, @buffer.drain_to_string)))
+  }
+
+  fn mut skip_spaces -> Result[Nil, ParseError] {
+    loop {
+      match @reader.peek {
+        case Ok(Some(SPC or TAB)) -> @reader.read_byte
+        case Ok(Some(_)) -> break
+        case Ok(_) -> throw ParseError.EndOfInput
+        case Error(e) -> throw ParseError.Read(e)
+      }
+    }
+
+    Result.Ok(nil)
+  }
+}

--- a/std/src/std/net/http/header.inko
+++ b/std/src/std/net/http/header.inko
@@ -1,0 +1,219 @@
+import std.bytes (Bytes)
+import std.ptr
+
+let MISSING = 63
+let MIN_SIZE = 3
+let MAX_SIZE = 32
+let MAX_HASH = 80
+
+let HASH = [
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 1, 81, 1, 35, 3, 1, 23, 19, 11, 81, 51, 18, 31, 39, 13, 5, 81, 20, 1,
+  14, 38, 14, 49, 81, 6, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81,
+  81, 81, 81, 81, 81, 81,
+]
+
+let WORDS = [
+  '',
+  '',
+  '',
+  '',
+  '',
+  '',
+  '',
+  'age',
+  '',
+  'alt-svc',
+  'cookie',
+  'expires',
+  'pragma',
+  '',
+  'set-cookie',
+  'accept-ranges',
+  'content-type',
+  'content-range',
+  'via',
+  'accept-language',
+  'content-language',
+  'accept',
+  'if-range',
+  'expect',
+  'vary',
+  'access-control-maxage',
+  'proxy-authenticate',
+  'server',
+  'range',
+  'accept-charset',
+  'etag',
+  'if-modified-since',
+  'cache-control',
+  'if-unmodified-since',
+  'content-length',
+  'access-control-allow-credentials',
+  'from',
+  'host',
+  'if-match',
+  'accept-encoding',
+  'content-encoding',
+  'trailer',
+  'date',
+  'if-none-match',
+  'max-forwards',
+  'access-control-requestheaders',
+  'access-control-request-methods',
+  'referer',
+  'upgrade',
+  'access-control-allow-headers',
+  'connection',
+  'retry-after',
+  'strict-transport-security',
+  'authorization',
+  'transfer-encoding',
+  'allow',
+  'content-location',
+  'access-control-method',
+  'origin',
+  'content-disposition',
+  'proxy-connection',
+  'access-control-allow-methods',
+  'user-agent',
+  'proxy-authorization',
+  'keep-alive',
+  'location',
+  'last-modified',
+  'upgrade-insecure-requests',
+  'www-authenticate',
+  '',
+  '',
+  '',
+  '',
+  'link',
+  '',
+  '',
+  '',
+  '',
+  '',
+  'access-control-request-method',
+  'access-control-allow-origin',
+]
+
+# A mapping of the values in WORDS to the values in the NAMES array.
+let INDEXES = [
+  -1, -1, -1, -1, -1, -1, -1, 14, -1, 16, 27, 31, 45, -1, 53, 4, 26, 25, 61, 3,
+  22, 0, 37, 30, 60, 9, 46, 52, 49, 1, 29, 35, 18, 38, 23, 5, 32, 33, 34, 2, 21,
+  55, 28, 36, 43, 13, 12, 50, 57, 6, 19, 51, 54, 17, 56, 15, 24, 10, 44, 20, 48,
+  7, 59, 47, 39, 42, 40, 58, 62, -1, -1, -1, -1, 41, -1, -1, -1, -1, -1, 11, 8,
+]
+
+# The names of the standard headers.
+let NAMES = [
+  'accept',
+  'accept-charset',
+  'accept-encoding',
+  'accept-language',
+  'accept-ranges',
+  'access-control-allow-credentials',
+  'access-control-allow-headers',
+  'access-control-allow-methods',
+  'access-control-allow-origin',
+  'access-control-maxage',
+  'access-control-method',
+  'access-control-request-method',
+  'access-control-request-methods',
+  'access-control-requestheaders',
+  'age',
+  'allow',
+  'alt-svc',
+  'authorization',
+  'cache-control',
+  'connection',
+  'content-disposition',
+  'content-encoding',
+  'content-language',
+  'content-length',
+  'content-location',
+  'content-range',
+  'content-type',
+  'cookie',
+  'date',
+  'etag',
+  'expect',
+  'expires',
+  'from',
+  'host',
+  'if-match',
+  'if-modified-since',
+  'if-none-match',
+  'if-range',
+  'if-unmodified-since',
+  'keep-alive',
+  'last-modified',
+  'link',
+  'location',
+  'max-forwards',
+  'origin',
+  'pragma',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'proxy-connection',
+  'range',
+  'referer',
+  'retry-after',
+  'server',
+  'set-cookie',
+  'strict-transport-security',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+  'upgrade-insecure-requests',
+  'user-agent',
+  'vary',
+  'via',
+  'www-authenticate',
+]
+
+fn hash[B: Bytes](input: ref B) -> Int {
+  let len = input.size
+  let mut val = len
+
+  if len > 21 { val = val + HASH.get(input.get(21).or_panic).or_panic }
+
+  let a = HASH.get(input.get(0).or_panic).or_panic
+  let b = HASH.get(input.get(len - 1).or_panic).or_panic
+
+  val + a + b
+}
+
+# Returns the index of a sequence of header name bytes.
+#
+# The implementation is based on the output of
+# `gperf --multiple-iterations=100 --global-table FILE` where `FILE` is a text
+# file containing the standard header names.
+fn index_of[B: Bytes](input: ref B) -> Int {
+  let len = input.size
+
+  if len < MIN_SIZE or len > MAX_SIZE { return MISSING }
+
+  let key = hash(input)
+
+  if key > MAX_HASH { return MISSING }
+
+  match WORDS.get(key) {
+    case
+      Ok(exp) if len == exp.size and ptr.equal(input.pointer, exp.pointer, len)
+    -> {
+      INDEXES.get(key).or_panic
+    }
+    case _ -> MISSING
+  }
+}

--- a/std/src/std/net/http/method.inko
+++ b/std/src/std/net/http/method.inko
@@ -1,0 +1,67 @@
+import std.bytes (Bytes)
+import std.ptr
+
+let MIN_SIZE = 3
+let MAX_SIZE = 7
+let MAX_HASH = 10
+
+let HASH = [
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 3, 3, 11, 11, 5, 2, 11, 11, 11, 11,
+  11, 11, 0, 0, 11, 11, 11, 0, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11, 11,
+  11, 11, 11, 11, 11, 11, 11,
+]
+
+let WORDS = [
+  '',
+  '',
+  '',
+  'PUT',
+  'POST',
+  'TRACE',
+  'HEAD',
+  'OPTIONS',
+  'GET',
+  'DELETE',
+  'CONNECT',
+]
+
+let INDEXES = [-1, -1, -1, 2, 1, 7, 4, 5, 0, 3, 6]
+
+fn hash[B: Bytes](input: ref B) -> Int {
+  input.size + HASH.get(input.get(0).or_panic).or_panic
+}
+
+# Returns the index of a sequence of request method name bytes.
+#
+# The implementation is based on the output of
+# `gperf --multiple-iterations=100 --global-table FILE` where `FILE` is a text
+# file containing the request method names.
+fn index_of[B: Bytes](input: ref B) -> Option[Int] {
+  let len = input.size
+
+  if len < MIN_SIZE or len > MAX_SIZE { return Option.None }
+
+  let key = hash(input)
+
+  if key > MAX_HASH { return Option.None }
+
+  match WORDS.get(key) {
+    case
+      Ok(exp) if len == exp.size and ptr.equal(input.pointer, exp.pointer, len)
+    -> {
+      INDEXES.get(key).ok
+    }
+    case _ -> Option.None
+  }
+}

--- a/std/test/std/net/test_http.inko
+++ b/std/test/std/net/test_http.inko
@@ -1,0 +1,328 @@
+import std.fmt (fmt)
+import std.int
+import std.io (Buffer)
+import std.net.http (
+  Bitmap, ChunkedReader, Header, HeaderMap, Method, MissingHeader, ParseError,
+  Status,
+)
+import std.net.http.header
+import std.test (Tests)
+
+fn pub tests(t: mut Tests) {
+  t.test('Header.parse', fn (t) {
+    t.equal(Header.parse('accept'), Header.Accept)
+    t.equal(Header.parse('www-authenticate'), Header.WwwAuthenticate)
+    t.equal(Header.parse('Accept'), Header.Other('Accept'))
+    t.equal(Header.parse('example-header'), Header.Other('example-header'))
+
+    for (idx, name) in header.NAMES.iter.with_index {
+      let header = Header.parse(name)
+
+      t.equal(header.index, idx)
+    }
+  })
+
+  t.test('Header.index', fn (t) {
+    for (idx, name) in header.NAMES.iter.with_index {
+      t.equal(Header.parse(name.to_lower).index, idx)
+    }
+  })
+
+  t.test('Header.==', fn (t) {
+    t.equal(Header.Accept, Header.Accept)
+    t.equal(Header.Other('foo'), Header.Other('foo'))
+    t.not_equal(Header.Accept, Header.Host)
+  })
+
+  t.test('Header.to_string', fn (t) {
+    t.equal(Header.Accept.to_string, 'accept')
+    t.equal(Header.ContentLength.to_string, 'content-length')
+    t.equal(Header.Other('example-header').to_string, 'example-header')
+  })
+
+  t.test('Header.fmt', fn (t) {
+    t.equal(fmt(Header.Accept), 'accept')
+    t.equal(fmt(Header.ContentLength), 'content-length')
+    t.equal(fmt(Header.Other('example-header')), 'example-header')
+  })
+
+  t.test('Bitmap.with', fn (t) {
+    t.equal(Bitmap.new.value, 0)
+    t.equal(Bitmap.new.with(4).value, 16)
+  })
+
+  t.test('Bitmap.contains?', fn (t) {
+    t.false(Bitmap.new.contains?(4))
+    t.true(Bitmap.new.with(4).contains?(4))
+    t.true(Bitmap.new.with(63).contains?(63))
+  })
+
+  t.test('MissingHeader.to_string', fn (t) {
+    t.equal(
+      MissingHeader(Header.Accept).to_string,
+      "the header 'accept' is missing",
+    )
+    t.equal(
+      MissingHeader(Header.Other('foo')).to_string,
+      "the header 'foo' is missing",
+    )
+  })
+
+  t.test('MissingHeader.fmt', fn (t) {
+    t.equal(fmt(MissingHeader(Header.Accept)), 'MissingHeader(header: accept)')
+  })
+
+  t.test('HeaderMap.new', fn (t) {
+    let map = HeaderMap.new
+
+    t.equal(map.bitmap.value, 0)
+    t.equal(map.standard.size, header.NAMES.size)
+    t.equal(map.non_standard.size, 0)
+  })
+
+  t.test('HeaderMap.add', fn (t) {
+    let map = HeaderMap.new
+
+    map.add(Header.Host, 'example.com')
+    map.add(Header.ContentLength, '10')
+    map.add(Header.ContentLength, '20')
+    map.add(Header.Other('foo'), '100')
+    map.add(Header.Other('bar'), '200')
+    map.add(Header.Other('bar'), '300')
+
+    t.true(map.bitmap.contains?(Header.Host.index))
+    t.true(map.bitmap.contains?(Header.ContentLength.index))
+    t.true(map.bitmap.contains?(Header.Other('foo').index))
+    t.true(map.bitmap.contains?(Header.Other('bar').index))
+
+    t.equal(map.get(Header.Host), Result.Ok('example.com'))
+    t.equal(map.get(Header.ContentLength), Result.Ok('10'))
+    t.equal(map.get(Header.Other('foo')), Result.Ok('100'))
+    t.equal(map.get(Header.Other('bar')), Result.Ok('200'))
+
+    t.equal(map.non_standard.size, 2)
+  })
+
+  t.test('HeaderMap.get', fn (t) {
+    let map = HeaderMap.new
+
+    map.add(Header.Host, 'example.com')
+    map.add(Header.Other('bar'), 'value')
+
+    t.equal(map.get(Header.Host), Result.Ok('example.com'))
+    t.equal(map.get(Header.Accept), Result.Error(MissingHeader(Header.Accept)))
+    t.equal(map.get(Header.Other('bar')), Result.Ok('value'))
+    t.equal(
+      map.get(Header.Other('foo')),
+      Result.Error(MissingHeader(Header.Other('foo'))),
+    )
+  })
+
+  t.test('HeaderMap.get_all', fn (t) {
+    let map = HeaderMap.new
+
+    map.add(Header.Host, 'example.com')
+    map.add(Header.ContentLength, '10')
+    map.add(Header.ContentLength, '20')
+    map.add(Header.Other('foo'), '100')
+    map.add(Header.Other('foo'), '200')
+    map.add(Header.Other('single'), 'value')
+
+    t.equal(map.get_all(Header.Host).to_array, ['example.com'])
+    t.equal(map.get_all(Header.ContentLength).to_array, ['10', '20'])
+    t.equal(map.get_all(Header.Other('foo')).to_array, ['100', '200'])
+    t.equal(map.get_all(Header.Other('single')).to_array, ['value'])
+
+    t.equal(map.get_all(Header.Via).to_array, [])
+    t.equal(map.get_all(Header.Other('missing')).to_array, [])
+  })
+
+  t.test('HeaderMap.fmt', fn (t) {
+    let map = HeaderMap.new
+
+    map.add(Header.Host, 'foo')
+    map.add(Header.Connection, 'bar')
+    map.add(Header.Connection, 'baz')
+    map.add(Header.Other('foo'), 'value1')
+    map.add(Header.Other('bar'), 'value2')
+    map.add(Header.Other('bar'), 'value3')
+
+    t.equal(
+      fmt(map),
+      '{connection: ["bar", "baz"], host: "foo", foo: "value1", bar: ["value2", "value3"]}',
+    )
+  })
+
+  t.test('Method.parse', fn (t) {
+    t.equal(Method.parse('GET'), Option.Some(Method.Get))
+    t.equal(Method.parse('OPTIONS'), Option.Some(Method.Options))
+    t.equal(Method.parse('get'), Option.None)
+  })
+
+  t.test('Method.==', fn (t) {
+    t.equal(Method.Get, Method.Get)
+    t.not_equal(Method.Get, Method.Post)
+  })
+
+  t.test('Method.to_string', fn (t) {
+    t.equal(Method.Get.to_string, 'GET')
+    t.equal(Method.Post.to_string, 'POST')
+    t.equal(Method.Put.to_string, 'PUT')
+    t.equal(Method.Delete.to_string, 'DELETE')
+    t.equal(Method.Head.to_string, 'HEAD')
+    t.equal(Method.Options.to_string, 'OPTIONS')
+    t.equal(Method.Connect.to_string, 'CONNECT')
+    t.equal(Method.Trace.to_string, 'TRACE')
+  })
+
+  t.test('Method.fmt', fn (t) {
+    t.equal(fmt(Method.Get), 'GET')
+    t.equal(fmt(Method.Post), 'POST')
+    t.equal(fmt(Method.Put), 'PUT')
+    t.equal(fmt(Method.Delete), 'DELETE')
+    t.equal(fmt(Method.Head), 'HEAD')
+    t.equal(fmt(Method.Options), 'OPTIONS')
+    t.equal(fmt(Method.Connect), 'CONNECT')
+    t.equal(fmt(Method.Trace), 'TRACE')
+  })
+
+  t.test('Status.new', fn (t) { t.equal(Status.new(404).code, 404) })
+
+  t.test('Status.ok', fn (t) { t.equal(Status.ok.code, 200) })
+
+  t.test('Status.==', fn (t) {
+    t.equal(Status.new(1), Status.new(1))
+    t.not_equal(Status.new(1), Status.new(2))
+  })
+
+  t.test('Status.to_string', fn (t) { t.equal(Status.ok.to_string, '200') })
+
+  t.test('Status.fmt', fn (t) { t.equal(fmt(Status.ok), '200') })
+
+  t.test('Status.to_int', fn (t) { t.equal(Status.ok.to_int, 200) })
+
+  t.test('ChunkedReader.read_chunk_size', fn (t) {
+    let tests = [
+      # Valid chunk sizes
+      ('1\r\n', 10, Result.Ok(1)),
+      ('10\r\n', 100, Result.Ok(16)),
+      ('FF\r\n', 512, Result.Ok(255)),
+      ('ff\r\n', 512, Result.Ok(255)),
+      ('3e7\r\n', 1024, Result.Ok(999)),
+      ('3E7\r\n', 1024, Result.Ok(999)),
+      ('10;\r\n', 256, Result.Ok(16)),
+      ('10;chunk extension\r\n', 256, Result.Ok(16)),
+      ('7fffffffffffffff\r\n', int.MAX, Result.Ok(int.MAX)),
+
+      # Invalid chunk sizes
+      ('FF\r\n', 10, Result.Error(ParseError.BodyTooLarge)),
+      ('Z\r\n', 10, Result.Error(ParseError.InvalidChunk)),
+      ('10;chunk extension\r\n', 5, Result.Error(ParseError.BodyTooLarge)),
+      ('10', 100, Result.Error(ParseError.EndOfInput)),
+      ('10\r', 100, Result.Error(ParseError.EndOfInput)),
+      ('10\rA', 100, Result.Error(ParseError.InvalidChunk)),
+      ('10;chunk extension', 100, Result.Error(ParseError.EndOfInput)),
+      ('10;chunk extension\r', 100, Result.Error(ParseError.EndOfInput)),
+      ('10;chunk extension\rA', 100, Result.Error(ParseError.InvalidChunk)),
+      ('8000000000000000\r\n', int.MAX, Result.Error(ParseError.InvalidChunk)),
+      ('00000000000000000\r\n', 100, Result.Error(ParseError.InvalidChunk)),
+      ('00000000000000001\r\n', 100, Result.Error(ParseError.InvalidChunk)),
+      ('000000000000000012\r\n', 100, Result.Error(ParseError.InvalidChunk)),
+    ]
+
+    for (inp, max, out) in tests {
+      t.equal(ChunkedReader.new(Buffer.new(inp), max).read_chunk_size, out)
+    }
+  })
+
+  t.test('ChunkedReader.read', fn (t) {
+    let tests = [
+      # Valid chunks
+      ('5\r\nhello\r\n', 1024, [(3, Result.Ok(3), 'hel')]),
+      ('5\r\nhello\r\n', 1024, [(5, Result.Ok(5), 'hello')]),
+      ('5\r\nhello\r\n', 1024, [(10, Result.Ok(5), 'hello')]),
+      ('3\r\nhel\r\n2\r\nlo\r\n', 1024, [(5, Result.Ok(5), 'hello')]),
+      ('3\r\nhel\r\n2\r\nlo\r\n', 1024, [(3, Result.Ok(3), 'hel')]),
+      (
+        '5\r\nhello\r\n',
+        1024,
+        [(3, Result.Ok(3), 'hel'), (2, Result.Ok(2), 'hello')],
+      ),
+      (
+        '5\r\nhello\r\n',
+        1024,
+        [(3, Result.Ok(3), 'hel'), (10, Result.Ok(2), 'hello')],
+      ),
+      (
+        '5\r\nhello\r\n0\r\n5\r\nworld\r\n',
+        1024,
+        [(5, Result.Ok(5), 'hello'), (5, Result.Ok(0), 'hello')],
+      ),
+      (
+        '5\r\nhello\r\n0\r\n5\r\nworld\r\n',
+        1024,
+        [(20, Result.Ok(5), 'hello'), (5, Result.Ok(0), 'hello')],
+      ),
+      ('3\r\nhel\r\n2\r\nlo\r\n0\r\n', 1024, [(20, Result.Ok(5), 'hello')]),
+
+      # Invalid chunks
+      ('5\r\nhello', 1024, [(5, Result.Error(ParseError.EndOfInput), 'hello')]),
+      (
+        '5\r\nhello\r',
+        1024,
+        [(5, Result.Error(ParseError.EndOfInput), 'hello')],
+      ),
+      (
+        '5\r\nhello\rX',
+        1024,
+        [(5, Result.Error(ParseError.InvalidChunk), 'hello')],
+      ),
+      (
+        '5\r\nhelloX',
+        1024,
+        [(5, Result.Error(ParseError.InvalidChunk), 'hello')],
+      ),
+
+      # Reads that are too large
+      ('5\r\nhello\r\n', 3, [(5, Result.Error(ParseError.BodyTooLarge), '')]),
+      (
+        '3\r\nhel\r\n2\r\nlo\r\n',
+        4,
+        [(4, Result.Error(ParseError.BodyTooLarge), 'hel')],
+      ),
+      (
+        '3\r\nhel\r\n2\r\nlo\r\n5\r\nworld\r\n',
+        5,
+        [
+          (5, Result.Ok(5), 'hello'),
+          (5, Result.Error(ParseError.BodyTooLarge), 'hello'),
+        ],
+      ),
+      (
+        '5;hello\r\nworld\r\n',
+        5,
+        [(5, Result.Error(ParseError.BodyTooLarge), '')],
+      ),
+      (
+        '5;hel\r\nworld\r\n',
+        5,
+        [(5, Result.Error(ParseError.BodyTooLarge), '')],
+      ),
+    ]
+
+    let buf = ByteArray.new
+
+    for (inp, max, reads) in tests {
+      let reader = ChunkedReader.new(Buffer.new(inp), max)
+
+      for (len, exp, out) in reads {
+        let res = reader.read(buf, len)
+
+        t.equal(res, exp)
+        t.equal(buf.to_string, out)
+      }
+
+      buf.clear
+    }
+  })
+}


### PR DESCRIPTION
Refer to https://github.com/inko-lang/inko/issues/734 and the individual commits for more details.

## TODO

- [ ] Resolve https://github.com/inko-lang/inko/issues/851 and https://github.com/inko-lang/inko/issues/808 first, as these basically block `main` from being green
- [ ] HTTP 1.1 client support
- [ ] HTTP 1.1 server support