### PR TITLE
Add Int.sign

### DIFF
--- a/std/src/std/int.inko
+++ b/std/src/std/int.inko
@@ -285,6 +285,20 @@ type builtin Int {
     }
   }
 
+  # Returns the value -1 or 1 based on the sign of the given number,
+  # 0 if the value is zero.
+  #
+  # # Examples
+  #
+  # ```inko
+  # -42.sign # => -1
+  # 42.sign  # => 1
+  # 0.sign   # => 0
+  # ```
+  fn pub inline sign -> Int {
+    if self > 0 { 1 } else if self == 0 { 0 } else { -1 }
+  }
+
   # Returns the absolute value of `self`.
   #
   # If `self` is equal to `std.int.MIN`, then the returned value is also

--- a/std/test/std/test_int.inko
+++ b/std/test/std/test_int.inko
@@ -126,6 +126,14 @@ fn pub tests(t: mut Tests) {
     t.equal(vals, [0, 1, 2])
   })
 
+  t.test('Int.sign', fn (t) {
+    t.equal(42.sign, 1)
+    t.equal(-42.sign, -1)
+    t.equal(0.sign, 0)
+    t.equal(-9223372036854775807.sign, -1)
+    t.equal(9223372036854775807.sign, 1)
+  })
+
   t.test('Int.absolute', fn (t) {
     t.equal(0.absolute, 0)
     t.equal(1.absolute, 1)


### PR DESCRIPTION
Define the `sign()` method for Int values.

Refer to https://en.wikipedia.org/wiki/Sign_function.

Changelog: added