### PR TITLE
Fix Json.to_pretty_string printing unnecessary whitespace

### DIFF
--- a/std/src/std/json.inko
+++ b/std/src/std/json.inko
@@ -1609,9 +1609,10 @@ type pub Generator {
               generate_value(val)
             }
           })
+
+          indent
         }
 
-        indent
         @buffer.push(']')
       }
       case Object(vals) -> {
@@ -1629,9 +1630,10 @@ type pub Generator {
               generate_value(v)
             }
           })
+
+          indent
         }
 
-        indent
         @buffer.push('}')
       }
       case Bool(val) -> @buffer.push(val.to_string)

--- a/std/test/std/test_json.inko
+++ b/std/test/std/test_json.inko
@@ -468,12 +468,15 @@ fn pub tests(t: mut Tests) {
     let map1 = Map.new
     let map2 = Map.new
     let map3 = Map.new
+    let map4 = Map.new
 
     map1.set('a', Json.Int(1))
     map1.set('b', Json.Int(2))
     map2.set('a', Json.Array([Json.Int(1), Json.Int(2)]))
     map3.set('a', Json.Int(1))
     map3.set('b', Json.Object(map2))
+    map4.set('a', Json.Array([]))
+    map4.set('b', Json.Object(Map.new))
 
     t.equal(Json.Object(Map.new).to_pretty_string, '{}')
     t.equal(
@@ -494,6 +497,14 @@ fn pub tests(t: mut Tests) {
       2
     ]
   }
+}',
+    )
+
+    t.equal(
+      Json.Object(map4).to_pretty_string,
+      '{
+  "a": [],
+  "b": {}
 }',
     )
   })


### PR DESCRIPTION
Fixes https://github.com/inko-lang/inko/issues/887

compiler/src/json.rs already formats empty collections correctly, so I simply adapted the code from there:

https://github.com/inko-lang/inko/blob/e0b55c0dd71fd9073caf59307bba812122cd836e/compiler/src/json.rs#L110-L113

The repro in the issue now prints the following:

```json
{
  "args": {},
  "numbers": []
}
```