### PR TITLE
Fix Zig linker compatibility for cross-compilation

### DIFF
--- a/compiler/src/linker.rs
+++ b/compiler/src/linker.rs
@@ -338,7 +338,15 @@ pub(crate) fn link(
         // "closing" `-Bdynamic` also affects any linker flags that come after
         // it, which can prevent us from static linking against e.g. libc for
         // musl targets.
-        let flag = if static_linking {
+        //
+        // The `-l:libX.a` syntax (note the colon) is a GNU ld/ld.lld extension
+        // that tells the linker to search for a file literally named
+        // `libX.a`. Zig's cc wrapper doesn't properly forward `-L` search
+        // paths to its internal linker for this syntax, so we fall back to
+        // `-lX` when using Zig. This still links the static library because
+        // `-L` search paths work correctly with `-lX`, and for
+        // cross-compilation there's unlikely to be a `.so` alongside the `.a`.
+        let flag = if static_linking && !state.config.linker.is_zig() {
             format!("-l:lib{}.a", lib)
         } else {
             format!("-l{}", lib)

--- a/compiler/src/linker.rs
+++ b/compiler/src/linker.rs
@@ -251,6 +251,19 @@ pub(crate) fn link(
         {
             cmd.arg(unwind);
         }
+
+    }
+
+    // When using Zig as the linker for GNU Linux targets, Zig's bundled
+    // glibc doesn't include libgcc_s which normally provides the
+    // _Unwind_* symbols. We instead link Zig's bundled libunwind.
+    // This applies to both native and cross-compilation, as Zig's
+    // sysroot is used in either case.
+    if state.config.linker.is_zig()
+        && state.config.target.os.is_linux()
+        && !state.config.target.abi.is_musl()
+    {
+        cmd.arg("-lunwind");
     }
 
     // Include any extra platform specific libraries, such as libm on the


### PR DESCRIPTION
- Skip `-l:libX.a` syntax with Zig linker (Zig's `cc` wrapper doesn't forward `-L` paths for this syntax; falls back to `-lX`)
- Link `-lunwind` for GNU Linux targets with Zig (Zig's bundled `glibc` lacks `libgcc_s`, which normally provides `_Unwind_*` symbols)

This now [cross compiles](https://docs.inko-lang.org/manual/latest/guides/cross-compilation/) for me (run from macOS ARM):

```sh
❯ git clone https://github.com/jhult/recalldory

❯ cd recalldory

❯ dnf install -y unzip zig

❯ curl -sL https://www.sqlite.org/2026/sqlite-amalgamation-3530000.zip -o sqlite-amalgamation-3530000.zip

❯ unzip -j sqlite-amalgamation-3530000.zip -d lib

❯ cd lib

❯ zig cc -c sqlite3.c \
            -DSQLITE_ENABLE_FTS5 \
            -DSQLITE_ENABLE_JSON1 \
            -target x86_64-linux-gnu \
            -o sqlite3.o

❯ zig ar rcs libsqlite3.a sqlite3.o

❯ cd ..

❯ inko runtime add amd64-linux-gnu

❯ inko build --release --target amd64-linux-gnu --linker zig --linker-arg "-L$PWD/lib" --static src/recalldory.inko
```

Get list of available Zig tagets: `zig targets 2>&1 | sed -n '/^    \.libc/,/^    }/p'`