### PR TITLE
Rename Path.from_slice to Path.from_iter

### DIFF
--- a/std/src/std/net/http/server.inko
+++ b/std/src/std/net/http/server.inko
@@ -3247,7 +3247,7 @@ type pub inline Directory {
   fn redirect_to_parent(components: array.Slice[Slice[String]]) -> Response {
     let dir = match components.split_last {
       case Some((_, head)) -> {
-        UriPath.root.join(UriPath.from_slice(head)).with_trailing_separator
+        UriPath.root.join(UriPath.from_iter(head.iter)).with_trailing_separator
       }
       case _ -> UriPath.root
     }

--- a/std/src/std/uri.inko
+++ b/std/src/std/uri.inko
@@ -28,7 +28,6 @@
 # When normalizing an international URI, multi-byte character sequences are
 # _not_ converted to their lowercase equivalent due to this being locale
 # specific.
-import std.array (Slice as ArraySlice)
 import std.bytes (Bytes, Slice, ToByteArray)
 import std.bytes.parsers (
   LOWER_A, UPPER_A, alpha?, digit?, hex?, lower?, lower_hex_char?, to_lower,
@@ -1173,27 +1172,29 @@ type pub inline Path {
     }
   }
 
-  # Returns a new `Path` from a `std.array.Slice` of percent-decoded path
-  # components.
+  # Returns a new `Path` from an iterator of percent-decoded path components.
   #
   # This method is useful when you've previously parsed a `Path` using e.g.
-  # `Path.components` and want to turn it back into a percent-encoded URI path.
+  # `Path.components`, or when you have a `String` of decoded components
+  # separated by `/`, and want to turn it into a percent-encoded URI path.
   #
   # # Examples
   #
   # ```inko
   # import std.uri (Path)
   #
+  # Path.from_iter('foo/bar/baz'.split('/')) # => Path('foo/bar/baz')
+  #
   # let path = Path.new('a/b/%20/c').get
   # let comp = path.components.to_array
   #
-  # Path.from_slice(comp.slice(0, comp.size - 1)) # => Path('a/b/%20')
+  # Path.from_iter(comp.slice(0, comp.size - 1).iter) # => Path('a/b/%20')
   # ```
-  fn pub static from_slice[B: Bytes](slice: ArraySlice[B]) -> Path {
+  fn pub static from_iter[B: Bytes, I: Iter[B]](iter: move I) -> Path {
     let buf = ByteArray.new
     let mut len = 0
 
-    for val in slice {
+    for val in iter {
       if len > 0 { buf.push(SLS) }
 
       encode_into(val, buf, tables.ENCODE_PATH)

--- a/std/test/std/test_uri.inko
+++ b/std/test/std/test_uri.inko
@@ -342,11 +342,19 @@ fn pub tests(t: mut Tests) {
     t.equal(Path.new('/%ff'), Option.Some(Path('/%ff')))
   })
 
-  t.test('Path.from_slice', fn (t) {
-    t.equal(Path.from_slice(([] as Array[String]).to_slice), Path(''))
-    t.equal(Path.from_slice(['a'].to_slice), Path('a'))
-    t.equal(Path.from_slice(['a', 'b'].to_slice), Path('a/b'))
-    t.equal(Path.from_slice(['a', 'b', '..', 'c'].to_slice), Path('a/b/../c'))
+  t.test('Path.from_iter', fn (t) {
+    t.equal(Path.from_iter(([] as Array[String]).iter), Path(''))
+    t.equal(Path.from_iter(['a'].iter), Path('a'))
+    t.equal(Path.from_iter(['a', 'b'].into_iter), Path('a/b'))
+    t.equal(Path.from_iter(['a', 'b', '..', 'c'].iter), Path('a/b/../c'))
+    t.equal(
+      Path.from_iter(Path.new('foo/bar/baz').get.components),
+      Path('foo/bar/baz'),
+    )
+    t.equal(
+      Path.from_iter('foo/bar/baz'.split('/').map(fn (v) { v })),
+      Path('foo/bar/baz'),
+    )
   })
 
   t.test('Path.join', fn (t) {


### PR DESCRIPTION
Rename `std.uri.Path.from_slice` to `Path.from_iter` so a path can be
built directly from an iterator of percent-decoded components (e.g.
`String.split('/')`) without allocating an intermediate `Array`.

Array slices still work via `slice.iter` / `slice.into_iter`.

This fixes https://github.com/inko-lang/inko/issues/1003.

Changelog: changed