### PR TITLE
Generate a README.md when running inko init

### DIFF
--- a/inko/src/command/init.rs
+++ b/inko/src/command/init.rs
@@ -66,6 +66,29 @@ jobs:
       - run: inko test
 ";
 
+const README: &str = "\
+# ${NAME}
+
+TODO
+
+# Requirements
+
+- Inko ${VERSION} or newer
+
+# Installation
+
+```bash
+inko pkg add URI/OF/OWNER/${NAME} 0.1.0
+inko pkg sync
+```
+
+# License
+
+All source code in this repository is licensed under the Mozilla Public License
+version 2.0, unless stated otherwise. A copy of this license is found in the
+file \"LICENSE\".
+";
+
 pub(crate) fn run(arguments: &[String]) -> Result<i32, Error> {
     let mut options = Options::new();
 
@@ -126,6 +149,12 @@ pub(crate) fn run(arguments: &[String]) -> Result<i32, Error> {
     create_file(&test.join(".gitkeep"), "")?;
     create_file(&main, if bin { BIN } else { "" })?;
     create_file(&root.join(".gitignore"), GITIGNORE)?;
+    create_file(
+        &root.join("README.md"),
+        &README
+            .replace("${NAME}", &name)
+            .replace("${VERSION}", &Version::inko().to_string()),
+    )?;
 
     let mut manifest = Manifest::new();
 

--- a/inko/src/command/init.rs
+++ b/inko/src/command/init.rs
@@ -89,6 +89,8 @@ version 2.0, unless stated otherwise. A copy of this license is found in the
 file \"LICENSE\".
 ";
 
+const LICENSE: &str = include_str!("../../../LICENSE");
+
 pub(crate) fn run(arguments: &[String]) -> Result<i32, Error> {
     let mut options = Options::new();
 
@@ -149,6 +151,7 @@ pub(crate) fn run(arguments: &[String]) -> Result<i32, Error> {
     create_file(&test.join(".gitkeep"), "")?;
     create_file(&main, if bin { BIN } else { "" })?;
     create_file(&root.join(".gitignore"), GITIGNORE)?;
+    create_file(&root.join("LICENSE"), LICENSE)?;
     create_file(
         &root.join("README.md"),
         &README

--- a/std/test/cmd/test_init.inko
+++ b/std/test/cmd/test_init.inko
@@ -64,12 +64,18 @@ fn pub tests(t: mut Tests) {
       t.true(root.join('.gitignore').file?)
       t.true(root.join('inko.pkg').file?)
       t.true(root.join('README.md').file?)
+      t.true(root.join('LICENSE').file?)
       t.true(readme.contains?('# hello'))
       t.true(readme.contains?('Inko ${version} or newer'))
       t.true(readme.contains?('inko pkg add URI/OF/OWNER/hello 0.1.0'))
       t.true(
         readme.contains?(
           'All source code in this repository is licensed under the Mozilla Public License',
+        ),
+      )
+      t.true(
+        (try read(root.join('LICENSE'))).contains?(
+          'Mozilla Public License, version 2.0',
         ),
       )
 
@@ -90,6 +96,7 @@ fn pub tests(t: mut Tests) {
       t.true(root.join('.gitignore').file?)
       t.true(root.join('inko.pkg').file?)
       t.true(root.join('README.md').file?)
+      t.true(root.join('LICENSE').file?)
 
       Result.Ok(nil)
     })
@@ -109,6 +116,7 @@ fn pub tests(t: mut Tests) {
       t.true(root.join('.gitignore').file?)
       t.true(root.join('inko.pkg').file?)
       t.true(root.join('README.md').file?)
+      t.true(root.join('LICENSE').file?)
 
       Result.Ok(nil)
     })

--- a/std/test/cmd/test_init.inko
+++ b/std/test/cmd/test_init.inko
@@ -49,12 +49,29 @@ fn pub tests(t: mut Tests) {
       let out = try init(dir, ['hello'])
       let root = dir.join('hello')
       let main = root.join('src').join('hello.inko')
+      let readme = try read(root.join('README.md'))
+      let pkg = try read(root.join('inko.pkg'))
+      let version = pkg
+        .trim
+        .to_string
+        .strip_prefix('require inko ')
+        .get
+        .to_string
 
       t.true(out.empty?)
       t.true(main.file?)
       t.true((try read(main)).contains?('type async Main'))
       t.true(root.join('.gitignore').file?)
       t.true(root.join('inko.pkg').file?)
+      t.true(root.join('README.md').file?)
+      t.true(readme.contains?('# hello'))
+      t.true(readme.contains?('Inko ${version} or newer'))
+      t.true(readme.contains?('inko pkg add URI/OF/OWNER/hello 0.1.0'))
+      t.true(
+        readme.contains?(
+          'All source code in this repository is licensed under the Mozilla Public License',
+        ),
+      )
 
       Result.Ok(nil)
     })
@@ -72,6 +89,7 @@ fn pub tests(t: mut Tests) {
       t.true((try read(main)).empty?)
       t.true(root.join('.gitignore').file?)
       t.true(root.join('inko.pkg').file?)
+      t.true(root.join('README.md').file?)
 
       Result.Ok(nil)
     })
@@ -90,6 +108,7 @@ fn pub tests(t: mut Tests) {
       t.true((try read(main)).contains?('type async Main'))
       t.true(root.join('.gitignore').file?)
       t.true(root.join('inko.pkg').file?)
+      t.true(root.join('README.md').file?)
 
       Result.Ok(nil)
     })


### PR DESCRIPTION
Generate a basic `README.md` (project name + current Inko version)
and an MPL-2.0 `LICENSE` when running `inko init`.

This fixes https://github.com/inko-lang/inko/issues/1001.
This fixes https://github.com/inko-lang/inko/issues/1000.

Changelog: added